### PR TITLE
docs: sync README/DOCKER with current code

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -32,6 +32,10 @@ Documentation: <https://docs.couchbase.com/mcp-server/get-started/overview.html>
 | `get_collections_in_scope` | Get a list of all the collections in a specified scope and bucket. Note that this tool requires the cluster to have Query service. |
 | `get_scopes_and_collections_in_bucket` | Get a list of all the scopes and collections in the specified bucket |
 | `get_schema_for_collection` | Get the structure for a collection |
+| `create_scope` | Create a new scope in a bucket (Couchbase Server 7.6+ and Capella). **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
+| `create_collection` | Create a new collection in an existing scope (Couchbase Server 7.6+ and Capella). **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
+| `delete_scope` | Delete a scope and all its collections from a bucket — permanent. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
+| `delete_collection` | Delete a collection and all its documents from a scope — permanent. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 
 ### Document KV operations tools
 
@@ -54,7 +58,7 @@ Documentation: <https://docs.couchbase.com/mcp-server/get-started/overview.html>
 | `create_index` | Create a scalar (non-vector) GSI secondary index on a collection. Deferred by default — call `build_index` afterward to build it. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 | `build_index` | Trigger the build of all deferred indexes on a collection. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 | `drop_index` | Drop a GSI index (scalar or vector) from a collection. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
-| `run_sql_plus_plus_query` | Run a [SQL++ query](https://www.couchbase.com/sqlplusplus/) on a specified scope.<br><br>Queries are automatically scoped to the specified bucket and scope, so use collection names directly (e.g., `SELECT * FROM users` instead of `SELECT * FROM bucket.scope.users`).<br><br>`CB_MCP_READ_ONLY_MODE` is `true` by default, which means that **all write operations (KV, Query, and index management)** are disabled. When enabled, KV and index write tools are not loaded and SQL++ queries that modify data are blocked. |
+| `run_sql_plus_plus_query` | Run a [SQL++ query](https://www.couchbase.com/sqlplusplus/) on a specified scope.<br><br>Queries are automatically scoped to the specified bucket and scope, so use collection names directly (e.g., `SELECT * FROM users` instead of `SELECT * FROM bucket.scope.users`).<br><br>`CB_MCP_READ_ONLY_MODE` is `true` by default, which means that **all write operations (KV, Query, scope/collection management, and index management)** are disabled. When enabled, KV, collection management, and index write tools are not loaded and SQL++ queries that modify data are blocked. |
 | `explain_sql_plus_plus_query` | Generate and evaluate an EXPLAIN plan for a SQL++ query. Returns query metadata, extracted plan, and plan evaluation findings. |
 
 ### Query performance analysis tools
@@ -117,7 +121,7 @@ The detailed explanation for the environment variables can be found on the [GitH
 | `CB_CLIENT_CERT_PATH`                | Path to the client certificate file for mTLS authentication                                                                                              | **Required if using mTLS (or Username and Password required)** |
 | `CB_CLIENT_KEY_PATH`                 | Path to the client key file for mTLS authentication                                                                                                      | **Required if using mTLS (or Username and Password required)** |
 | `CB_CA_CERT_PATH`                    | Path to server root certificate for TLS if server is configured with a self-signed/untrusted certificate.                                                |                                                                |
-| `CB_MCP_READ_ONLY_MODE`              | Prevent all data modifications (KV, Query, and index management). When `true`, KV and index write tools are not loaded.                                                               | `true`                                                         |
+| `CB_MCP_READ_ONLY_MODE`              | Prevent all data modifications (KV, Query, scope/collection management, and index management). When `true`, KV, collection management, and index write tools are not loaded.                                                               | `true`                                                         |
 | `CB_MCP_TRANSPORT`                   | Transport mode (stdio/http/sse)                                                                                                                          | `stdio`                                                        |
 | `CB_MCP_HOST`                        | Server host (HTTP/SSE modes)                                                                                                                             | `127.0.0.1`                                                    |
 | `CB_MCP_PORT`                        | Server port (HTTP/SSE modes)                                                                                                                             | `8000`                                                         |
@@ -246,7 +250,7 @@ Lines starting with `#` are treated as comments and ignored.
 >
 > For example, even if you disable `upsert_document_by_id` and `delete_document_by_id`, data modifications can still occur via the `run_sql_plus_plus_query` tool using SQL++ DML statements (INSERT, UPDATE, DELETE, MERGE) unless:
 >
-> - The `CB_MCP_READ_ONLY_MODE` is set to `true` (default), which disables all write operations (KV, Query, and index management), OR
+> - The `CB_MCP_READ_ONLY_MODE` is set to `true` (default), which disables all write operations (KV, Query, scope/collection management, and index management), OR
 > - The database user lacks the necessary RBAC permissions for data modification
 >
 > **Best Practice:** Always configure appropriate RBAC permissions on your Couchbase user credentials as the primary security measure. Use `CB_MCP_READ_ONLY_MODE=true` (the default) for comprehensive write protection, and tool disabling as an additional layer to guide LLM behavior.
@@ -331,6 +335,6 @@ OAuth is configured with the `CB_MCP_OAUTH_*` variables in the [Environment Vari
 
 - OAuth activates only when all three of `CB_MCP_OAUTH_JWT_JWKS_URI`, `CB_MCP_OAUTH_JWT_ISSUER`, and `CB_MCP_OAUTH_JWT_AUDIENCE` are set; setting only some of them fails at startup.
 - Setting `CB_MCP_OAUTH_MCP_BASE_URL` additionally publishes RFC 9728 Protected Resource Metadata so PRM-aware clients can discover the authorization server.
-- Access is gated by two scopes read from the token's `scope`/`scp` claim: `couchbase-mcp:read` (read tools, including SQL++) and `couchbase-mcp:write` (write tools: KV mutations and index management). Full access requires both. If your IdP can't emit those canonical labels, override them with `CB_MCP_OAUTH_SCOPE_READ_LABEL` / `CB_MCP_OAUTH_SCOPE_WRITE_LABEL`.
+- Access is gated by two scopes read from the token's `scope`/`scp` claim: `couchbase-mcp:read` (read tools, including SQL++) and `couchbase-mcp:write` (write tools: KV mutations, scope/collection management, and index management). Full access requires both. If your IdP can't emit those canonical labels, override them with `CB_MCP_OAUTH_SCOPE_READ_LABEL` / `CB_MCP_OAUTH_SCOPE_WRITE_LABEL`.
 
 For full details, see the [documentation](https://docs.couchbase.com/mcp-server/configuration/oauth-overview.html).

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Once the server is connected, you can talk to your Couchbase cluster in natural 
 | `get_server_configuration_status` | Get the server status and configuration without connecting to the cluster — reports read-only mode, disabled/confirmation-required tools, OAuth settings, and the resolved logging configuration |
 | `test_cluster_connection` | Check the cluster credentials by connecting to the cluster |
 | `get_cluster_health_and_services` | Get cluster health status and list of all running services, optionally filtered to specific services via `service_types` |
-| `get_cluster_diagnostics_report` | Get the SDK's cached connection diagnostics — whether connections were already broken and for how long, without any active network probing | main
+| `get_cluster_diagnostics_report` | Get the SDK's cached connection diagnostics — whether connections were already broken and for how long, without any active network probing |
 
 ### Data model & schema discovery tools
 

--- a/src/cb_mcp/utils/context.py
+++ b/src/cb_mcp/utils/context.py
@@ -20,8 +20,9 @@ class AppContext:
             captured once at lifespan startup. Tools should read values
             from here via :func:`cb_mcp.utils.config.get_settings` rather than
             reaching for a module global.
-        read_only_mode: When True, all write operations (KV, Query, and index
-            management) are disabled and KV and index write tools are not loaded.
+        read_only_mode: When True, all write operations (KV, Query,
+            scope/collection management, and index management) are disabled
+            and KV, collection management, and index write tools are not loaded.
         logging_config: Optional snapshot of the active logging configuration,
             populated by the server entrypoint after configuring its loggers.
     """

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -84,7 +84,7 @@ logger = logging.getLogger(MCP_SERVER_NAME)
     envvar="CB_MCP_READ_ONLY_MODE",
     type=bool,
     default=DEFAULT_READ_ONLY_MODE,
-    help="Enable read-only mode. When True, all write operations (KV and Query) are disabled and KV write tools are not loaded. Set to False to enable write operations.",
+    help="Enable read-only mode. When True, all write operations (KV, Query, scope/collection management, and index management) are disabled and KV, collection management, and index write tools are not loaded. Set to False to enable write operations.",
 )
 @click.option(
     "--transport",


### PR DESCRIPTION
## Related Issue

Docs were not up to date

## What does this change do?

Update docs

## Checklist

- [ ] Linked to an issue (required for new tools). The issue can be on JIRA (preferred for internal contributors) or GitHub.
- [ ] Uses the Couchbase SDK (REST fallback justified in the description, if any)
- [ ] Works on both Capella and self-managed Couchbase Server
- [ ] No changes to `cb_mcp.core` contracts / managed MCP interfaces (or discussed first)
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (for cluster-touching changes)
- [ ] Read-only mode and tool annotations handled (for new/changed tools)
- [ ] Evidence of testing included above
- [ ] Docs updated (README, DOCKER.md) for user-facing changes
- [x] Lint and pre-commit pass
