### PR TITLE
Update: EA Tools based on Murtadha's recommendation

### DIFF
--- a/analytics-mcp/src/ea_mcp/tools/metadata.py
+++ b/analytics-mcp/src/ea_mcp/tools/metadata.py
@@ -127,13 +127,16 @@ def get_schema_for_collection(
     collection_name: str,
     sample_size: int = 1000,
 ) -> list[dict[str, Any]]:
-    """Infer the JSON schema of a collection by sampling documents.
+    """Infer the JSON schema of a collection using Analytics' built-in
+    ARRAY_INFER_SCHEMA function, sampling up to sample_size documents.
 
-    Samples up to sample_size documents from the collection and reports each
-    field's inferred type and how many sampled documents had it. sample_size
-    must be positive and is capped at MAX_SCHEMA_SAMPLE_SIZE.
+    ARRAY_INFER_SCHEMA detects distinct structural "flavors" across the
+    sample and returns one JSON-Schema-shaped object per flavor (with
+    per-property type/percentage/sample-value stats) — this is the same
+    function the Capella UI uses for schema inference. sample_size must be
+    positive and is capped at MAX_SCHEMA_SAMPLE_SIZE.
 
-    Returns a list of rows, each with field, data_type, and occurrences.
+    Returns a list of JSON-Schema-shaped objects, one per detected flavor.
     """
     if sample_size <= 0:
         raise ValueError(f"sample_size must be positive, got {sample_size}")
@@ -144,18 +147,10 @@ def get_schema_for_collection(
         f"{safe_ident(collection_name)}"
     )
     query = (
-        f"SELECT p.name AS field, t AS data_type, COUNT(*) AS occurrences "
-        f"FROM (SELECT VALUE d FROM {keyspace} AS d LIMIT $sample_size) AS d "
-        f"UNNEST OBJECT_PAIRS(d) AS p "
-        f"LET t = CASE "
-        f'WHEN is_number(p.`value`) THEN "number" '
-        f'WHEN is_string(p.`value`) THEN "string" '
-        f'WHEN is_boolean(p.`value`) THEN "boolean" '
-        f'WHEN is_array(p.`value`) THEN "array" '
-        f'WHEN is_object(p.`value`) THEN "object" '
-        f'ELSE "null/unknown" END '
-        f"GROUP BY p.name, t "
-        f"ORDER BY field, occurrences DESC;"
+        "SELECT s.* "
+        "FROM ARRAY_INFER_SCHEMA("
+        f"(SELECT VALUE d FROM {keyspace} AS d LIMIT $sample_size)"
+        ") AS s;"
     )
     try:
         logger.debug(f"Inferring schema for {keyspace}")

--- a/analytics-mcp/src/ea_mcp/tools/metadata.py
+++ b/analytics-mcp/src/ea_mcp/tools/metadata.py
@@ -147,10 +147,9 @@ def get_schema_for_collection(
         f"{safe_ident(collection_name)}"
     )
     query = (
-        "SELECT s.* "
-        "FROM ARRAY_INFER_SCHEMA("
+        "SELECT VALUE ARRAY_INFER_SCHEMA("
         f"(SELECT VALUE d FROM {keyspace} AS d LIMIT $sample_size)"
-        ") AS s;"
+        ");"
     )
     try:
         logger.debug(f"Inferring schema for {keyspace}")
@@ -158,11 +157,16 @@ def get_schema_for_collection(
         result = cluster.execute_query(
             query, QueryOptions(named_parameters={"sample_size": sample_size})
         )
+        # SELECT VALUE over a bare array_infer_schema() call returns exactly
+        # one row whose value is the array of flavor objects itself — unwrap
+        # it so this tool returns a flat list of flavor objects like its
+        # other list-returning siblings.
         rows = result.get_all_rows()
+        flavors = rows[0] if rows else []
         logger.info(
             f"Inferred schema for {keyspace} from {sample_size} sampled document(s)"
         )
-        return rows
+        return flavors
     except Exception as e:
         logger.error(f"Error inferring schema for {keyspace}: {e}", exc_info=True)
         raise

--- a/analytics-mcp/src/ea_mcp/tools/metadata.py
+++ b/analytics-mcp/src/ea_mcp/tools/metadata.py
@@ -83,12 +83,14 @@ def get_collections_in_scope(
 ) -> list[dict[str, Any]]:
     """List all collections (datasets) in a scope.
 
-    Returns a list of rows, each with DatabaseName, ScopeName, and
-    CollectionName fields.
+    Returns a list of rows, each with DatabaseName, ScopeName,
+    CollectionName, and Type fields. Type is the collection's DatasetType
+    (INTERNAL, EXTERNAL, or VIEW) — callers that only want stored/linked
+    collections should filter out Type == "VIEW" themselves.
     """
     query = (
         "SELECT d.DatabaseName, d.DataverseName AS ScopeName, "
-        "d.DatasetName AS CollectionName "
+        "d.DatasetName AS CollectionName, d.DatasetType AS Type "
         "FROM System.Metadata.`Dataset` d "
         'WHERE d.DataverseName <> "Metadata" '
         "AND d.DatabaseName = $database_name AND d.DataverseName = $scope_name;"

--- a/analytics-mcp/src/ea_mcp/tools/metadata.py
+++ b/analytics-mcp/src/ea_mcp/tools/metadata.py
@@ -90,7 +90,7 @@ def get_collections_in_scope(
     """
     query = (
         "SELECT d.DatabaseName, d.DataverseName AS ScopeName, "
-        "d.DatasetName AS CollectionName, d.DatasetType AS Type "
+        "d.DatasetName AS CollectionName, d.DatasetType AS `Type` "
         "FROM System.Metadata.`Dataset` d "
         'WHERE d.DataverseName <> "Metadata" '
         "AND d.DatabaseName = $database_name AND d.DataverseName = $scope_name;"

--- a/analytics-mcp/tests/integration/test_metadata_tools.py
+++ b/analytics-mcp/tests/integration/test_metadata_tools.py
@@ -16,6 +16,26 @@ from conftest import create_mcp_session, extract_payload
 DATABASE = "Default"
 
 
+def _collect_keys(obj: object) -> set[str]:
+    """Recursively collect every dict key appearing anywhere in obj.
+
+    array_infer_schema's exact envelope (top-level key names, nesting) isn't
+    pinned down by the docs, but it's documented to return "JSON Schema
+    format" — meaning inferred property names always end up as dict keys
+    somewhere in the structure. Walking for keys lets tests check that a
+    field was detected without assuming an unconfirmed envelope shape.
+    """
+    keys: set[str] = set()
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            keys.add(key)
+            keys |= _collect_keys(value)
+    elif isinstance(obj, list):
+        for item in obj:
+            keys |= _collect_keys(item)
+    return keys
+
+
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_get_databases_in_cluster() -> None:
@@ -94,8 +114,8 @@ async def test_get_collections_in_scope_and_schema() -> None:
                 },
             )
             schema = extract_payload(schema_response)
-            fields = {row["field"] for row in schema}
-            assert {"id", "name", "count"} <= fields
+            assert isinstance(schema, list) and len(schema) > 0
+            assert {"id", "name", "count"} <= _collect_keys(schema)
         finally:
             await session.call_tool(
                 "run_query_sync",

--- a/analytics-mcp/tests/unit/test_metadata_tools_unit.py
+++ b/analytics-mcp/tests/unit/test_metadata_tools_unit.py
@@ -117,16 +117,18 @@ class TestGetCollectionsInScope:
 class TestGetSchemaForCollection:
     def test_returns_rows_on_success(self) -> None:
         ctx, cluster = _make_ctx_with_cluster()
-        cluster.execute_query.return_value.get_all_rows.return_value = [
-            {"field": "id", "data_type": "string", "occurrences": 2}
-        ]
+        # SELECT VALUE array_infer_schema(...) yields a single row whose
+        # value is the array of detected flavor objects. The exact envelope
+        # shape isn't asserted on here — this is a pass-through check.
+        flavors = [{"properties": {"id": {"type": ["string"]}}}]
+        cluster.execute_query.return_value.get_all_rows.return_value = [flavors]
 
         with patch(
             "ea_mcp.tools.metadata.get_cluster_connection", return_value=cluster
         ):
             result = get_schema_for_collection(ctx, "Default", "Default", "eatest_coll")
 
-        assert result == [{"field": "id", "data_type": "string", "occurrences": 2}]
+        assert result == flavors
 
     def test_raises_on_sdk_error(self) -> None:
         ctx, cluster = _make_ctx_with_cluster()


### PR DESCRIPTION
Resolves:

Murtadha's recommendations in EA tools

## Evidence of Testing

```
# e.g. uv run pytest analytics-mcp/src/ea_mcp/tests  →  20 passed
```

**Environments tested** (both are required):

- [ ] Capella Analytics (Not supported as of now)
- [x] Self-managed Enterprise Analytics

## Checklist

- [ ] Linked to an issue (required for new tools). The issue can be on JIRA (preferred for internal contributors) or GitHub.
- [ ] Uses the Couchbase SDK (REST fallback justified in the description, if any)
- [ ] Works on both Capella and self-managed Couchbase Server
- [ ] No changes to `cb_mcp.core` contracts / managed MCP interfaces (or discussed first)
- [x] Unit tests added/updated
- [x] Integration tests added/updated (for cluster-touching changes)
- [ ] Read-only mode and tool annotations handled (for new/changed tools)
- [x] Evidence of testing included above
- [x] Docs updated (README, DOCKER.md) for user-facing changes
- [x] Lint and pre-commit pass
