### PR TITLE
DA-2070: Add explain query tool

### DIFF
--- a/analytics-mcp/README.md
+++ b/analytics-mcp/README.md
@@ -1,6 +1,6 @@
 # couchbase-analytics-mcp-server (prototype)
 
-A small, throwaway FastMCP server exposing tools for Couchbase Enterprise Analytics (EA),
+A small demo FastMCP server exposing tools for Couchbase Enterprise Analytics (EA),
 built on the `couchbase-analytics` Python SDK (not the operational `couchbase` SDK used by
 the parent `mcp-server-couchbase` server).
 
@@ -26,6 +26,7 @@ EA_CONNECTION_STRING=http://localhost:8095 EA_USERNAME=Administrator EA_PASSWORD
 | `get_collections_in_scope` | List all collections (datasets) in a scope |
 | `get_schema_for_collection` | Infer the JSON schema of a collection by sampling documents |
 | `run_query_sync` | Run a SQL++ statement and buffer all result rows in memory |
+| `explain_query` | Generate the query plan for a SQL++ statement using EXPLAIN (without executing it); pass the statement without an EXPLAIN keyword |
 
 ## Tests
 

--- a/analytics-mcp/src/ea_mcp/tools/__init__.py
+++ b/analytics-mcp/src/ea_mcp/tools/__init__.py
@@ -1,7 +1,7 @@
 """Enterprise Analytics (EA) prototype MCP tools.
 
 Flat tool set — no read/write split, no read-only-mode gating, unlike the
-parent ``cb_mcp.tools`` package. All 5 tools are registered unconditionally.
+parent ``cb_mcp.tools`` package. All 6 tools are registered unconditionally.
 """
 
 from collections.abc import Callable
@@ -14,7 +14,7 @@ from .metadata import (
     get_schema_for_collection,
     get_scopes_in_database,
 )
-from .query import run_query_sync
+from .query import explain_query, run_query_sync
 
 TOOLS: list[Callable] = [
     get_databases_in_cluster,
@@ -22,6 +22,7 @@ TOOLS: list[Callable] = [
     get_collections_in_scope,
     get_schema_for_collection,
     run_query_sync,
+    explain_query,
 ]
 
 TOOL_ANNOTATIONS: dict[str, ToolAnnotations] = {
@@ -32,11 +33,13 @@ TOOL_ANNOTATIONS: dict[str, ToolAnnotations] = {
     # run_query_sync can carry DDL/DML per the tool spec, so it gets no
     # readOnlyHint (matches run_sql_plus_plus_query in the parent server).
     "run_query_sync": ToolAnnotations(),
+    "explain_query": ToolAnnotations(readOnlyHint=True),
 }
 
 __all__ = [
     "TOOLS",
     "TOOL_ANNOTATIONS",
+    "explain_query",
     "get_collections_in_scope",
     "get_databases_in_cluster",
     "get_schema_for_collection",

--- a/analytics-mcp/src/ea_mcp/tools/metadata.py
+++ b/analytics-mcp/src/ea_mcp/tools/metadata.py
@@ -134,7 +134,7 @@ def get_schema_for_collection(
     sample and returns one JSON-Schema-shaped object per flavor (with
     per-property type/percentage/sample-value stats) — this is the same
     function the Capella UI uses for schema inference. sample_size must be
-    positive and is capped at MAX_SCHEMA_SAMPLE_SIZE.
+    positive and is capped at 10_000.
 
     Returns a list of JSON-Schema-shaped objects, one per detected flavor.
     """

--- a/analytics-mcp/src/ea_mcp/tools/query.py
+++ b/analytics-mcp/src/ea_mcp/tools/query.py
@@ -5,9 +5,8 @@ package — it follows the parent server's write-tool convention: catch
 Exception, log, and return a {"success": False, "error": ...} envelope
 instead of raising.
 
-explain_query never executes the statement it's given, so it follows the
-metadata tools' read-tool convention instead: raise on error, return the raw
-list of rows.
+explain_query follows the same convention: catch Exception, log, and return
+a {"success": False, "error": ...} envelope instead of raising.
 """
 
 import logging
@@ -42,7 +41,7 @@ def run_query_sync(ctx: Context, statement: str) -> dict[str, Any]:
         return tool_error(e, statement=statement)
 
 
-def explain_query(ctx: Context, statement: str) -> list[dict[str, Any]]:
+def explain_query(ctx: Context, statement: str) -> dict[str, Any]:
     """Generate the query plan for a SQL++ statement using EXPLAIN, without executing it.
 
     Whether the plan is cost-based or rule-based depends on whether the
@@ -51,7 +50,8 @@ def explain_query(ctx: Context, statement: str) -> list[dict[str, Any]]:
 
     Pass the statement without an EXPLAIN keyword; it is added automatically.
 
-    Returns the raw EXPLAIN result rows.
+    Returns {"success": True, "plan": [...]} on success, or
+    {"success": False, "error": "..."} on failure.
     """
     cluster = get_cluster_connection(ctx)
     try:
@@ -59,7 +59,7 @@ def explain_query(ctx: Context, statement: str) -> list[dict[str, Any]]:
         result = cluster.execute_query(f"EXPLAIN {statement}")
         rows = result.get_all_rows()
         logger.info(f"EXPLAIN returned {len(rows)} row(s)")
-        return rows
+        return tool_success(plan=rows)
     except Exception as e:
         logger.error(f"Error running EXPLAIN: {e}", exc_info=True)
-        raise
+        return tool_error(e, statement=statement)

--- a/analytics-mcp/src/ea_mcp/tools/query.py
+++ b/analytics-mcp/src/ea_mcp/tools/query.py
@@ -4,6 +4,10 @@ run_query_sync can carry DDL/DML, so — unlike the metadata tools in this
 package — it follows the parent server's write-tool convention: catch
 Exception, log, and return a {"success": False, "error": ...} envelope
 instead of raising.
+
+explain_query never executes the statement it's given, so it follows the
+metadata tools' read-tool convention instead: raise on error, return the raw
+list of rows.
 """
 
 import logging
@@ -36,3 +40,26 @@ def run_query_sync(ctx: Context, statement: str) -> dict[str, Any]:
     except Exception as e:
         logger.error(f"Error running query: {e}", exc_info=True)
         return tool_error(e, statement=statement)
+
+
+def explain_query(ctx: Context, statement: str) -> list[dict[str, Any]]:
+    """Generate the query plan for a SQL++ statement using EXPLAIN, without executing it.
+
+    Whether the plan is cost-based or rule-based depends on whether the
+    optimizer has collected samples for the target collection(s) — this tool
+    just returns whatever plan the optimizer produces.
+
+    Pass the statement without an EXPLAIN keyword; it is added automatically.
+
+    Returns the raw EXPLAIN result rows.
+    """
+    cluster = get_cluster_connection(ctx)
+    try:
+        logger.debug("Running EXPLAIN for SQL++ statement")
+        result = cluster.execute_query(f"EXPLAIN {statement}")
+        rows = result.get_all_rows()
+        logger.info(f"EXPLAIN returned {len(rows)} row(s)")
+        return rows
+    except Exception as e:
+        logger.error(f"Error running EXPLAIN: {e}", exc_info=True)
+        raise

--- a/analytics-mcp/tests/integration/test_query_tools.py
+++ b/analytics-mcp/tests/integration/test_query_tools.py
@@ -31,3 +31,42 @@ async def test_run_query_sync_invalid_statement_returns_error_envelope() -> None
 
         assert payload["success"] is False
         assert "error" in payload
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_explain_query_returns_plan() -> None:
+    async with create_mcp_session() as session:
+        response = await session.call_tool(
+            "explain_query", arguments={"statement": "SELECT 1 AS one"}
+        )
+        payload = extract_payload(response)
+
+        assert isinstance(payload, list)
+        assert len(payload) > 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_explain_query_does_not_execute_statement() -> None:
+    async with create_mcp_session() as session:
+        response = await session.call_tool(
+            "explain_query",
+            arguments={"statement": "SELECT 1 / 0 AS boom"},
+        )
+        payload = extract_payload(response)
+
+        # A division-by-zero would fail if the statement were actually
+        # executed; EXPLAIN only plans it, so this should succeed.
+        assert isinstance(payload, list)
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_explain_query_invalid_statement_raises() -> None:
+    async with create_mcp_session() as session:
+        response = await session.call_tool(
+            "explain_query", arguments={"statement": "SELECT bad("}
+        )
+
+        assert response.isError is True

--- a/analytics-mcp/tests/integration/test_query_tools.py
+++ b/analytics-mcp/tests/integration/test_query_tools.py
@@ -42,8 +42,8 @@ async def test_explain_query_returns_plan() -> None:
         )
         payload = extract_payload(response)
 
-        assert isinstance(payload, list)
-        assert len(payload) > 0
+        assert payload["success"] is True
+        assert len(payload["plan"]) > 0
 
 
 @pytest.mark.asyncio
@@ -58,15 +58,17 @@ async def test_explain_query_does_not_execute_statement() -> None:
 
         # A division-by-zero would fail if the statement were actually
         # executed; EXPLAIN only plans it, so this should succeed.
-        assert isinstance(payload, list)
+        assert payload["success"] is True
 
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_explain_query_invalid_statement_raises() -> None:
+async def test_explain_query_invalid_statement_returns_error_envelope() -> None:
     async with create_mcp_session() as session:
         response = await session.call_tool(
             "explain_query", arguments={"statement": "SELECT bad("}
         )
+        payload = extract_payload(response)
 
-        assert response.isError is True
+        assert payload["success"] is False
+        assert "error" in payload

--- a/analytics-mcp/tests/unit/test_query_tools_unit.py
+++ b/analytics-mcp/tests/unit/test_query_tools_unit.py
@@ -1,13 +1,17 @@
 """Unit tests for query execution tools.
 
-Mocks the cluster so these tests can cover the error branches (returned as
-{"success": False, "error": ...}, never raised) without a live cluster.
+Mocks the cluster so these tests can cover the error branches without a live
+cluster. run_query_sync returns {"success": False, "error": ...} on error;
+explain_query raises instead (it follows the read-tool convention since it
+never executes the statement it's given).
 """
 
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from ea_mcp.tools.query import run_query_sync
+import pytest
+
+from ea_mcp.tools.query import explain_query, run_query_sync
 
 
 def _make_ctx_with_cluster() -> tuple[SimpleNamespace, MagicMock]:
@@ -42,3 +46,25 @@ class TestRunQuerySync:
             "error": "syntax error",
             "statement": "SELECT bad(",
         }
+
+
+class TestExplainQuery:
+    def test_prepends_explain_to_statement(self) -> None:
+        ctx, cluster = _make_ctx_with_cluster()
+        cluster.execute_query.return_value.get_all_rows.return_value = [{"plan": {}}]
+
+        with patch("ea_mcp.tools.query.get_cluster_connection", return_value=cluster):
+            result = explain_query(ctx, "SELECT 1 AS one")
+
+        cluster.execute_query.assert_called_once_with("EXPLAIN SELECT 1 AS one")
+        assert result == [{"plan": {}}]
+
+    def test_raises_on_sdk_error(self) -> None:
+        ctx, cluster = _make_ctx_with_cluster()
+        cluster.execute_query.side_effect = Exception("syntax error")
+
+        with (
+            patch("ea_mcp.tools.query.get_cluster_connection", return_value=cluster),
+            pytest.raises(Exception, match="syntax error"),
+        ):
+            explain_query(ctx, "SELECT bad(")

--- a/analytics-mcp/tests/unit/test_query_tools_unit.py
+++ b/analytics-mcp/tests/unit/test_query_tools_unit.py
@@ -1,15 +1,11 @@
 """Unit tests for query execution tools.
 
-Mocks the cluster so these tests can cover the error branches without a live
-cluster. run_query_sync returns {"success": False, "error": ...} on error;
-explain_query raises instead (it follows the read-tool convention since it
-never executes the statement it's given).
+Mocks the cluster so these tests can cover the error branches (returned as
+{"success": False, "error": ...}, never raised) without a live cluster.
 """
 
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 from ea_mcp.tools.query import explain_query, run_query_sync
 
@@ -57,14 +53,17 @@ class TestExplainQuery:
             result = explain_query(ctx, "SELECT 1 AS one")
 
         cluster.execute_query.assert_called_once_with("EXPLAIN SELECT 1 AS one")
-        assert result == [{"plan": {}}]
+        assert result == {"success": True, "plan": [{"plan": {}}]}
 
-    def test_raises_on_sdk_error(self) -> None:
+    def test_returns_error_envelope_on_sdk_error(self) -> None:
         ctx, cluster = _make_ctx_with_cluster()
         cluster.execute_query.side_effect = Exception("syntax error")
 
-        with (
-            patch("ea_mcp.tools.query.get_cluster_connection", return_value=cluster),
-            pytest.raises(Exception, match="syntax error"),
-        ):
-            explain_query(ctx, "SELECT bad(")
+        with patch("ea_mcp.tools.query.get_cluster_connection", return_value=cluster):
+            result = explain_query(ctx, "SELECT bad(")
+
+        assert result == {
+            "success": False,
+            "error": "syntax error",
+            "statement": "SELECT bad(",
+        }


### PR DESCRIPTION
## Related Issue

Resolves: https://jira.issues.couchbase.com/browse/DA-2070

## What does this change do?

Add explain query tool to EA mcp

## Evidence of Testing

<!-- PRs without testing evidence will be sent back before review. See "Evidence of testing" in CONTRIBUTING.md. -->

**Automated tests** — commands run and results summary:

```
uv run --extra dev pytest analytics-mcp/tests →  25 passed
```

**Environments tested** (both are required):

- [ ] Capella Analytics (not supported yet)
- [x] Self-managed Enterprise Analytics

## Checklist

- [x] Linked to an issue (required for new tools). The issue can be on JIRA (preferred for internal contributors) or GitHub.
- [ ] Uses the Couchbase SDK (REST fallback justified in the description, if any)
- [ ] Works on both Capella and self-managed Couchbase Server
- [ ] No changes to `cb_mcp.core` contracts / managed MCP interfaces (or discussed first)
- [x] Unit tests added/updated
- [x] Integration tests added/updated (for cluster-touching changes)
- [ ] Read-only mode and tool annotations handled (for new/changed tools)
- [x] Evidence of testing included above
- [x] Docs updated (README, DOCKER.md) for user-facing changes
- [x] Lint and pre-commit pass
