### PR TITLE
Add http mode in ea

### DIFF
--- a/analytics-mcp/src/ea_mcp_server.py
+++ b/analytics-mcp/src/ea_mcp_server.py
@@ -41,7 +41,34 @@ MCP_SERVER_NAME = "couchbase-enterprise-analytics-mcp"
     required=True,
     help="Enterprise Analytics password",
 )
-def main(connection_string: str, username: str, password: str) -> None:
+@click.option(
+    "--transport",
+    envvar="EA_MCP_TRANSPORT",
+    type=click.Choice(["stdio", "http"]),
+    default="stdio",
+    help="MCP transport to serve on",
+)
+@click.option(
+    "--host",
+    envvar="EA_MCP_HOST",
+    default="127.0.0.1",
+    help="Host to bind when --transport=http",
+)
+@click.option(
+    "--port",
+    envvar="EA_MCP_PORT",
+    default=8000,
+    type=int,
+    help="Port to bind when --transport=http",
+)
+def main(
+    connection_string: str,
+    username: str,
+    password: str,
+    transport: str,
+    host: str,
+    port: int,
+) -> None:
     """Couchbase Enterprise Analytics MCP server (prototype)."""
     logging.basicConfig(level=logging.INFO)
 
@@ -62,7 +89,10 @@ def main(connection_string: str, username: str, password: str) -> None:
         mcp.add_tool(tool_obj)
 
     logger.info(f"Registered {len(TOOLS)} tool(s)")
-    mcp.run(transport="stdio", show_banner=False)
+    if transport == "http":
+        mcp.run(transport="http", host=host, port=port, show_banner=False)
+    else:
+        mcp.run(transport="stdio", show_banner=False)
 
 
 if __name__ == "__main__":

--- a/analytics-mcp/src/ea_mcp_server.py
+++ b/analytics-mcp/src/ea_mcp_server.py
@@ -90,7 +90,7 @@ def main(
 
     logger.info(f"Registered {len(TOOLS)} tool(s)")
     if transport == "http":
-        mcp.run(transport="http", host=host, port=port, show_banner=False)
+        mcp.run(transport="streamable-http", host=host, port=port, show_banner=False)
     else:
         mcp.run(transport="stdio", show_banner=False)
 


### PR DESCRIPTION
## What does this change do?
Add http transport mode to EA mcp

## Evidence of Testing

```
uv run pytest tests/ →  passed
```

**Environments tested** (both are required):

- [ ] Capella Analytics (not supported)
- [ ] Self-managed Couchbase Server (version2.2.0)

## Checklist

- [ ] Linked to an issue (required for new tools). The issue can be on JIRA (preferred for internal contributors) or GitHub.
- [ ] Uses the Couchbase SDK (REST fallback justified in the description, if any)
- [ ] Works on both Capella and self-managed Couchbase Server
- [ ] No changes to `cb_mcp.core` contracts / managed MCP interfaces (or discussed first)
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (for cluster-touching changes)
- [ ] Read-only mode and tool annotations handled (for new/changed tools)
- [ ] Evidence of testing included above
- [x] Docs updated (README, DOCKER.md) for user-facing changes
- [x] Lint and pre-commit pass
