### PR TITLE
fix: propagate version artifact through workflow_run chain to unblock MCP registry updates

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -137,3 +137,19 @@ jobs:
           REGISTRY: "public"
           TAG_LATEST: ${{ steps.check-stable.outputs.is_stable }}
           JOB_NAME: "docker-publish"
+
+      - name: Save version for downstream workflows
+        env:
+          VERSION: ${{ github.event.inputs.version || steps.artifact-version.outputs.version }}
+        run: |
+          if [ -z "$VERSION" ]; then
+            echo "ERROR: VERSION is empty, cannot save version artifact"
+            exit 1
+          fi
+          echo "$VERSION" > version.txt
+
+      - name: Upload version artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-version
+          path: version.txt

--- a/.github/workflows/update-mcp-registry.yml
+++ b/.github/workflows/update-mcp-registry.yml
@@ -7,13 +7,39 @@ on:
       - completed
 
 jobs:
+  gate:
+    # Downloads the version artifact from Docker and checks if this is a version tag run.
+    # workflow_run chains always execute on the default branch, so head_branch is always
+    # "main" by this point — we use the artifact to recover the original tag name instead.
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      actions: read
+    outputs:
+      version: ${{ steps.read-version.outputs.version }}
+      is-version-tag: ${{ steps.read-version.outputs.is-version-tag }}
+    steps:
+      - name: Download version artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: release-version
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read and validate version tag
+        id: read-version
+        run: |
+          VERSION=$(tr -d '\r\n' < version.txt)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "is-version-tag=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is-version-tag=false" >> "$GITHUB_OUTPUT"
+          fi
+
   check-and-update-registry:
-    # Only run on version tag releases (originating from a tag push) and if the docker workflow succeeded.
-    # Docker is now a downstream workflow_run job (not push-triggered), so event == 'push' is omitted;
-    # startsWith(head_branch, 'v') is sufficient to identify version tag runs through the chain.
-    if: |
-      github.event.workflow_run.conclusion == 'success' &&
-      startsWith(github.event.workflow_run.head_branch, 'v')
+    needs: gate
+    if: needs.gate.outputs.is-version-tag == 'true'
 
     runs-on: ubuntu-latest
     permissions:
@@ -24,28 +50,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.workflow_run.head_branch }}
-
-      - name: Wait for PyPI release to complete
-        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be # v1.2.0
-        id: wait-for-pypi
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: "Upload to PyPI via Jenkins"
-          ref: ${{ github.event.workflow_run.head_sha }}
-          timeoutSeconds: 600
-          intervalSeconds: 10
-
-      - name: Check PyPI release status
-        if: steps.wait-for-pypi.outputs.conclusion != 'success'
-        run: |
-          echo "PyPI release did not succeed. Status: ${{ steps.wait-for-pypi.outputs.conclusion }}"
-          exit 1
+          ref: ${{ needs.gate.outputs.version }}
 
       - name: Validate version consistency
         id: version
         env:
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_BRANCH: ${{ needs.gate.outputs.version }}
         run: |
           # Read versions from files
           ROOT_VERSION=$(jq -r '.version' server.json)


### PR DESCRIPTION
<!--
Thank you for contributing to the Couchbase MCP Server!
Please read CONTRIBUTING.md before submitting. Keep PRs small and focused —
one tool, one bug fix, or one refactor per PR.
-->

## Related Issue

<!-- Every PR must link to an issue (JIRA ticket for Couchbase internal contributors, GitHub issue for external). Required for new tools — the tool interface must be agreed in the issue before implementation. -->

Resolves:

## What does this change do?
To ensure that the tag is passed to update mcp registry action from the docker build and push action more deterministically

## Why is this change needed?
The tag is passed to update mcp registry action from the docker build and push action more deterministically

## Evidence of Testing

<!-- PRs without testing evidence will be sent back before review. See "Evidence of testing" in CONTRIBUTING.md. -->

**Automated tests** — commands run and results summary:
TBD

```
# e.g. uv run pytest tests/unit/  →  142 passed
# e.g. uv run pytest tests/integration/  →  38 passed, 2 skipped
```

**Environments tested** (both are required):

- [ ] Couchbase Capella (version: ____)
- [ ] Self-managed Couchbase Server (version: ____, e.g. via Docker)

**Manual verification** — MCP client used (Claude Desktop, Cursor, MCP Inspector, ...) and what was exercised. Screenshots or tool-call transcripts are very helpful:

## Compatibility Considerations

<!-- Note any impact on: Capella vs. self-managed behavior, managed MCP interfaces (cb_mcp.core), existing tool names/parameters/return shapes, CLI flags, environment variables, or new dependencies. Write "None" if not applicable. -->

## Checklist

- [ ] Linked to an issue (required for new tools). The issue can be on JIRA (preferred for internal contributors) or GitHub.
- [ ] Uses the Couchbase SDK (REST fallback justified in the description, if any)
- [ ] Works on both Capella and self-managed Couchbase Server
- [X] No changes to `cb_mcp.core` contracts / managed MCP interfaces (or discussed first)
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (for cluster-touching changes)
- [ ] Read-only mode and tool annotations handled (for new/changed tools)
- [ ] Evidence of testing included above
- [ ] Docs updated (README, DOCKER.md) for user-facing changes
- [ ] Lint and pre-commit pass
