### PR TITLE
feat: add durability and expiry options to KV write tools

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -39,10 +39,10 @@ Documentation: <https://docs.couchbase.com/mcp-server/get-started/overview.html>
 | --------- | ----------- |
 | `get_document_by_id` | Get a document by ID from a specified scope and collection |
 | `lookup_subdocument` | Look up parts of a document (specific fields, existence checks, or array/object counts) by path without fetching the whole document |
-| `upsert_document_by_id` | Upsert a document by ID to a specified scope and collection. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
-| `insert_document_by_id` | Insert a new document by ID (fails if document exists). **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
-| `replace_document_by_id` | Replace an existing document by ID (fails if document doesn't exist). **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
-| `delete_document_by_id` | Delete a document by ID from a specified scope and collection. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
+| `upsert_document_by_id` | Upsert a document by ID to a specified scope and collection. Optionally takes `durability` and `expiry_seconds`. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
+| `insert_document_by_id` | Insert a new document by ID (fails if document exists). Optionally takes `durability` and `expiry_seconds`. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
+| `replace_document_by_id` | Replace an existing document by ID (fails if document doesn't exist). Optionally takes `durability` and `expiry_seconds`. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
+| `delete_document_by_id` | Delete a document by ID from a specified scope and collection. Optionally takes `durability`. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 | `mutate_subdocument` | Modify parts of an existing document (upsert, insert, replace, remove, array ops, counters) by path without rewriting the whole document. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 
 ### Query and indexing tools

--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ Once the server is connected, you can talk to your Couchbase cluster in natural 
 | --------- | ----------- |
 | `get_document_by_id` | Get a document by ID from a specified scope and collection |
 | `lookup_subdocument` | Look up parts of a document (specific fields, existence checks, or array/object counts) by path without fetching the whole document |
-| `upsert_document_by_id` | Upsert a document by ID to a specified scope and collection. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
-| `insert_document_by_id` | Insert a new document by ID (fails if document exists). **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
-| `replace_document_by_id` | Replace an existing document by ID (fails if document doesn't exist). **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
-| `delete_document_by_id` | Delete a document by ID from a specified scope and collection. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
+| `upsert_document_by_id` | Upsert a document by ID to a specified scope and collection. Optionally takes `durability` and `expiry_seconds`. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
+| `insert_document_by_id` | Insert a new document by ID (fails if document exists). Optionally takes `durability` and `expiry_seconds`. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
+| `replace_document_by_id` | Replace an existing document by ID (fails if document doesn't exist). Optionally takes `durability` and `expiry_seconds`. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
+| `delete_document_by_id` | Delete a document by ID from a specified scope and collection. Optionally takes `durability`. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 | `mutate_subdocument` | Modify parts of an existing document (upsert, insert, replace, remove, array ops, counters) by path without rewriting the whole document. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 
 ### Query and indexing tools

--- a/src/cb_mcp/tools/kv.py
+++ b/src/cb_mcp/tools/kv.py
@@ -11,10 +11,18 @@ This module contains tools for document operations by ID:
 
 import json
 import logging
+from datetime import timedelta
 from typing import Any
 
 import couchbase.subdocument as subdoc
+from couchbase.durability import DurabilityLevel, ServerDurability
 from couchbase.exceptions import CouchbaseException
+from couchbase.options import (
+    InsertOptions,
+    RemoveOptions,
+    ReplaceOptions,
+    UpsertOptions,
+)
 from fastmcp import Context
 
 from ..utils.connection import connect_to_bucket, format_keyspace
@@ -23,6 +31,63 @@ from ..utils.context import get_cluster_connection
 from ..utils.responses import tool_error, tool_success
 
 logger = logging.getLogger(f"{MCP_SERVER_NAME}.tools.kv")
+
+# Durability levels accepted by the ``durability`` parameter of the write
+# tools, mapped to the SDK enum. Exposed as strings because MCP tool
+# parameters are JSON-typed and LLM-generated; the mapping doubles as input
+# validation at the tool boundary.
+DURABILITY_LEVELS: dict[str, DurabilityLevel] = {
+    "NONE": DurabilityLevel.NONE,
+    "MAJORITY": DurabilityLevel.MAJORITY,
+    "MAJORITY_AND_PERSIST_TO_ACTIVE": DurabilityLevel.MAJORITY_AND_PERSIST_TO_ACTIVE,
+    "PERSIST_TO_MAJORITY": DurabilityLevel.PERSIST_TO_MAJORITY,
+}
+
+
+def _write_options(
+    option_cls: Any,
+    durability: str | None = None,
+    expiry_seconds: int | None = None,
+) -> Any:
+    """Build an SDK options object for a KV write, or None if nothing is set.
+
+    Returning None when no option is requested keeps the call path identical
+    to the one used before these parameters existed, so default behavior is
+    unchanged.
+
+    Raises ValueError for an unknown durability level or a negative expiry so
+    the calling tool can report an actionable message rather than handing an
+    invalid value to the SDK.
+    """
+    kwargs: dict[str, Any] = {}
+
+    if durability is not None:
+        level = DURABILITY_LEVELS.get(durability)
+        if level is None:
+            raise ValueError(
+                f"durability must be one of {sorted(DURABILITY_LEVELS)}; "
+                f"got {durability!r}"
+            )
+        # The SDK reads the ``durability`` option key and derives the
+        # wire-level durability_level from it. ``durability_level`` is not a
+        # supported option key: the Options classes are unvalidated dict
+        # subclasses, so passing it is accepted and then silently dropped,
+        # which would turn the guarantee into a no-op.
+        kwargs["durability"] = ServerDurability(level=level)
+
+    if expiry_seconds is not None:
+        if expiry_seconds < 0:
+            raise ValueError(
+                f"expiry_seconds must be zero or positive; got {expiry_seconds}"
+            )
+        # Couchbase treats an expiry of 0 as "no expiry", which is also how
+        # the SDK interprets a zero timedelta, so 0 clears an existing TTL.
+        kwargs["expiry"] = timedelta(seconds=expiry_seconds)
+
+    if not kwargs:
+        return None
+    return option_cls(**kwargs)
+
 
 
 def get_document_by_id(
@@ -56,6 +121,8 @@ def upsert_document_by_id(
     collection_name: str,
     document_id: str,
     document_content: dict[str, Any],
+    durability: str | None = None,
+    expiry_seconds: int | None = None,
 ) -> dict[str, Any]:
     """Insert or update a document by its ID.
 
@@ -64,15 +131,41 @@ def upsert_document_by_id(
 
     DO NOT use this as a fallback when insert_document_by_id or replace_document_by_id fails.
 
+    durability: how durable the write must be before the tool reports success:
+    "NONE" acknowledges from the active node's memory only, "MAJORITY" waits
+    for a majority of replicas to hold it in memory,
+    "MAJORITY_AND_PERSIST_TO_ACTIVE" adds a write to disk on the active node,
+    and "PERSIST_TO_MAJORITY" waits for a disk write on a majority of nodes.
+    Stronger levels cost latency and FAIL outright if the cluster has too few
+    replicas to satisfy them. Omit this parameter for the cluster's own
+    default; passing "NONE" explicitly requests no durability.
+
+    expiry_seconds: time-to-live in seconds, after which the document is
+    deleted automatically. 0 means no expiry. IMPORTANT: this is a
+    full-document write, which resets the document's expiry either way -
+    omitting this parameter clears any TTL the document already had, it does
+    not preserve it. Pass the intended TTL on every write to a document that
+    should keep expiring.
+
     Returns {"success": True} on success, or {"success": False, "error": "..."} on
-    failure with the reason (e.g. permission denied, network error, invalid content)."""
+    failure with the reason (e.g. permission denied, network error, invalid content,
+    durability not satisfiable by this cluster)."""
     keyspace = format_keyspace(bucket_name, scope_name, collection_name)
+    try:
+        options = _write_options(UpsertOptions, durability, expiry_seconds)
+    except ValueError as e:
+        logger.warning(f"Invalid upsert options for {keyspace}: {e}")
+        return tool_error(e)
+
     cluster = get_cluster_connection(ctx)
     bucket = connect_to_bucket(cluster, bucket_name)
     try:
         logger.debug(f"Upserting document in {keyspace}")
         collection = bucket.scope(scope_name).collection(collection_name)
-        collection.upsert(document_id, document_content)
+        if options is None:
+            collection.upsert(document_id, document_content)
+        else:
+            collection.upsert(document_id, document_content, options)
         logger.info(f"Successfully upserted document in {keyspace}")
         return tool_success()
     except Exception as e:
@@ -86,18 +179,38 @@ def delete_document_by_id(
     scope_name: str,
     collection_name: str,
     document_id: str,
+    durability: str | None = None,
 ) -> dict[str, Any]:
     """Delete a document by its ID.
 
+    durability: how durable the write must be before the tool reports success:
+    "NONE" acknowledges from the active node's memory only, "MAJORITY" waits
+    for a majority of replicas to hold it in memory,
+    "MAJORITY_AND_PERSIST_TO_ACTIVE" adds a write to disk on the active node,
+    and "PERSIST_TO_MAJORITY" waits for a disk write on a majority of nodes.
+    Stronger levels cost latency and FAIL outright if the cluster has too few
+    replicas to satisfy them. Omit this parameter for the cluster's own
+    default; passing "NONE" explicitly requests no durability.
+
     Returns {"success": True} on success, or {"success": False, "error": "..."} on
-    failure with the reason (e.g. document not found, permission denied, network error)."""
+    failure with the reason (e.g. document not found, permission denied, network error,
+    durability not satisfiable by this cluster)."""
     keyspace = format_keyspace(bucket_name, scope_name, collection_name)
+    try:
+        options = _write_options(RemoveOptions, durability)
+    except ValueError as e:
+        logger.warning(f"Invalid delete options for {keyspace}: {e}")
+        return tool_error(e)
+
     cluster = get_cluster_connection(ctx)
     bucket = connect_to_bucket(cluster, bucket_name)
     try:
         logger.debug(f"Deleting document from {keyspace}")
         collection = bucket.scope(scope_name).collection(collection_name)
-        collection.remove(document_id)
+        if options is None:
+            collection.remove(document_id)
+        else:
+            collection.remove(document_id, options)
         logger.info(f"Successfully deleted document from {keyspace}")
         return tool_success()
     except Exception as e:
@@ -112,21 +225,45 @@ def insert_document_by_id(
     collection_name: str,
     document_id: str,
     document_content: dict[str, Any],
+    durability: str | None = None,
+    expiry_seconds: int | None = None,
 ) -> dict[str, Any]:
     """Insert a new document by its ID. This operation will FAIL if the document already exists.
 
     IMPORTANT: If this operation fails, DO NOT automatically try replace or upsert.
     Report the failure to the user. They can choose to 'replace' or 'upsert' if desired.
 
+    durability: how durable the write must be before the tool reports success:
+    "NONE" acknowledges from the active node's memory only, "MAJORITY" waits
+    for a majority of replicas to hold it in memory,
+    "MAJORITY_AND_PERSIST_TO_ACTIVE" adds a write to disk on the active node,
+    and "PERSIST_TO_MAJORITY" waits for a disk write on a majority of nodes.
+    Stronger levels cost latency and FAIL outright if the cluster has too few
+    replicas to satisfy them. Omit this parameter for the cluster's own
+    default; passing "NONE" explicitly requests no durability.
+
+    expiry_seconds: time-to-live in seconds, after which the document is
+    deleted automatically. 0 means no expiry.
+
     Returns {"success": True} on success, or {"success": False, "error": "..."} on
-    failure with the reason (e.g. document already exists, permission denied, network error)."""
+    failure with the reason (e.g. document already exists, permission denied, network
+    error, durability not satisfiable by this cluster)."""
     keyspace = format_keyspace(bucket_name, scope_name, collection_name)
+    try:
+        options = _write_options(InsertOptions, durability, expiry_seconds)
+    except ValueError as e:
+        logger.warning(f"Invalid insert options for {keyspace}: {e}")
+        return tool_error(e)
+
     cluster = get_cluster_connection(ctx)
     bucket = connect_to_bucket(cluster, bucket_name)
     try:
         logger.debug(f"Inserting document in {keyspace}")
         collection = bucket.scope(scope_name).collection(collection_name)
-        collection.insert(document_id, document_content)
+        if options is None:
+            collection.insert(document_id, document_content)
+        else:
+            collection.insert(document_id, document_content, options)
         logger.info(f"Successfully inserted document in {keyspace}")
         return tool_success()
     except Exception as e:
@@ -141,21 +278,49 @@ def replace_document_by_id(
     collection_name: str,
     document_id: str,
     document_content: dict[str, Any],
+    durability: str | None = None,
+    expiry_seconds: int | None = None,
 ) -> dict[str, Any]:
     """Replace an existing document by its ID. This operation will FAIL if the document does not exist.
 
     IMPORTANT: If this operation fails, DO NOT automatically try insert or upsert.
     Report the failure to the user. They can choose to 'insert' or 'upsert' if desired.
 
+    durability: how durable the write must be before the tool reports success:
+    "NONE" acknowledges from the active node's memory only, "MAJORITY" waits
+    for a majority of replicas to hold it in memory,
+    "MAJORITY_AND_PERSIST_TO_ACTIVE" adds a write to disk on the active node,
+    and "PERSIST_TO_MAJORITY" waits for a disk write on a majority of nodes.
+    Stronger levels cost latency and FAIL outright if the cluster has too few
+    replicas to satisfy them. Omit this parameter for the cluster's own
+    default; passing "NONE" explicitly requests no durability.
+
+    expiry_seconds: time-to-live in seconds, after which the document is
+    deleted automatically. 0 means no expiry. IMPORTANT: this is a
+    full-document write, which resets the document's expiry either way -
+    omitting this parameter clears any TTL the document already had, it does
+    not preserve it. Pass the intended TTL on every write to a document that
+    should keep expiring.
+
     Returns {"success": True} on success, or {"success": False, "error": "..."} on
-    failure with the reason (e.g. document does not exist, permission denied, network error)."""
+    failure with the reason (e.g. document does not exist, permission denied, network
+    error, durability not satisfiable by this cluster)."""
     keyspace = format_keyspace(bucket_name, scope_name, collection_name)
+    try:
+        options = _write_options(ReplaceOptions, durability, expiry_seconds)
+    except ValueError as e:
+        logger.warning(f"Invalid replace options for {keyspace}: {e}")
+        return tool_error(e)
+
     cluster = get_cluster_connection(ctx)
     bucket = connect_to_bucket(cluster, bucket_name)
     try:
         logger.debug(f"Replacing document in {keyspace}")
         collection = bucket.scope(scope_name).collection(collection_name)
-        collection.replace(document_id, document_content)
+        if options is None:
+            collection.replace(document_id, document_content)
+        else:
+            collection.replace(document_id, document_content, options)
         logger.info(f"Successfully replaced document in {keyspace}")
         return tool_success()
     except Exception as e:

--- a/tests/integration/test_kv_write_options.py
+++ b/tests/integration/test_kv_write_options.py
@@ -1,0 +1,231 @@
+"""
+Integration tests for the durability and expiry options on the KV write tools.
+
+These cover what only a live server can show: that a TTL actually expires the
+document, and that a durability level is genuinely evaluated by the cluster
+rather than accepted and ignored.
+
+The durability test asserts the cluster either satisfies MAJORITY or refuses
+it as impossible, without inspecting the topology first - both are correct
+answers, and neither is available to an option that was silently dropped.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import pytest
+from conftest import (
+    create_mcp_session,
+    extract_payload,
+    get_test_collection,
+    get_test_scope,
+    is_error_response,
+    require_test_bucket,
+)
+
+
+def _keyspace() -> dict[str, str]:
+    return {
+        "bucket_name": require_test_bucket(),
+        "scope_name": get_test_scope(),
+        "collection_name": get_test_collection(),
+    }
+
+
+async def _delete(session, doc_id: str) -> None:
+    await session.call_tool(
+        "delete_document_by_id",
+        arguments={**_keyspace(), "document_id": doc_id},
+    )
+
+
+@pytest.mark.asyncio
+async def test_durability_is_evaluated_by_the_cluster() -> None:
+    """A MAJORITY write must be either satisfied or refused - never quietly
+    downgraded.
+
+    Both outcomes are correct and which one occurs depends on the cluster:
+    with a replica the write is acknowledged, without one the server refuses
+    it as impossible. What neither outcome allows is the failure this test
+    exists to catch - an option that never reaches the server, which would
+    report plain success on a cluster that cannot possibly provide the
+    guarantee.
+
+    Deliberately does not inspect the cluster's topology first. Ping reports
+    the endpoints the SDK currently holds connections to rather than the
+    cluster's actual node count, so branching on it produces a test whose
+    result depends on connection order.
+    """
+    doc_id = f"test_dur_{uuid.uuid4().hex[:8]}"
+
+    async with create_mcp_session() as session:
+        response = await session.call_tool(
+            "upsert_document_by_id",
+            arguments={
+                **_keyspace(),
+                "document_id": doc_id,
+                "document_content": {"durable": True},
+                "durability": "MAJORITY",
+            },
+        )
+        payload = extract_payload(response)
+
+        try:
+            assert isinstance(payload, dict), (
+                f"the tool rejected the call outright rather than running it, "
+                f"which usually means the server does not have the durability "
+                f"parameter: {payload}"
+            )
+
+            if payload["success"]:
+                # Satisfied: the document must really be there.
+                stored = extract_payload(
+                    await session.call_tool(
+                        "get_document_by_id",
+                        arguments={**_keyspace(), "document_id": doc_id},
+                    )
+                )
+                assert stored == {"durable": True}, (
+                    f"durable write reported success but the document is "
+                    f"wrong: {stored}"
+                )
+            else:
+                # Refused: it must be refused *for a durability reason*. Any
+                # other error means something unrelated broke.
+                error = payload.get("error", "")
+                assert "durab" in error.lower(), (
+                    "expected the cluster either to satisfy MAJORITY or to "
+                    f"refuse it as a durability failure, got: {payload}"
+                )
+        finally:
+            await _delete(session, doc_id)
+
+
+@pytest.mark.asyncio
+async def test_none_durability_is_accepted_everywhere() -> None:
+    """NONE is satisfiable on every topology, so this proves the parameter is
+    plumbed through regardless of how the test cluster is built."""
+    doc_id = f"test_dur_{uuid.uuid4().hex[:8]}"
+
+    async with create_mcp_session() as session:
+        response = await session.call_tool(
+            "upsert_document_by_id",
+            arguments={
+                **_keyspace(),
+                "document_id": doc_id,
+                "document_content": {"durable": False},
+                "durability": "NONE",
+            },
+        )
+        payload = extract_payload(response)
+        try:
+            assert payload["success"] is True, (
+                f"expected NONE durability to succeed, got {payload}"
+            )
+        finally:
+            await _delete(session, doc_id)
+
+
+@pytest.mark.asyncio
+async def test_invalid_durability_is_rejected_and_nothing_is_written() -> None:
+    """An unusable option must not degrade into an unguarded write."""
+    doc_id = f"test_bad_{uuid.uuid4().hex[:8]}"
+
+    async with create_mcp_session() as session:
+        response = await session.call_tool(
+            "upsert_document_by_id",
+            arguments={
+                **_keyspace(),
+                "document_id": doc_id,
+                "document_content": {"should_not": "exist"},
+                "durability": "MAJORITY_ISH",
+            },
+        )
+        payload = extract_payload(response)
+        assert payload["success"] is False
+        assert "MAJORITY_ISH" in payload["error"]
+
+        get_response = await session.call_tool(
+            "get_document_by_id",
+            arguments={**_keyspace(), "document_id": doc_id},
+        )
+        if not is_error_response(get_response):
+            await _delete(session, doc_id)
+            pytest.fail("a rejected write must not have created the document")
+
+
+@pytest.mark.asyncio
+async def test_expiry_seconds_actually_expires_the_document() -> None:
+    """The server applies expiry lazily, so this polls rather than sleeping
+    once for a guessed interval."""
+    doc_id = f"test_ttl_{uuid.uuid4().hex[:8]}"
+
+    async with create_mcp_session() as session:
+        response = await session.call_tool(
+            "upsert_document_by_id",
+            arguments={
+                **_keyspace(),
+                "document_id": doc_id,
+                "document_content": {"transient": True},
+                "expiry_seconds": 1,
+            },
+        )
+        assert extract_payload(response)["success"] is True
+
+        for _ in range(20):
+            await asyncio.sleep(1)
+            get_response = await session.call_tool(
+                "get_document_by_id",
+                arguments={**_keyspace(), "document_id": doc_id},
+            )
+            if is_error_response(get_response):
+                return
+
+        await _delete(session, doc_id)
+        pytest.fail("document with a 1 second TTL was still readable after 20s")
+
+
+@pytest.mark.asyncio
+async def test_insert_accepts_durability_and_expiry() -> None:
+    """insert takes the same options as upsert; a divergence here would be a
+    silently inconsistent tool surface."""
+    doc_id = f"test_ins_{uuid.uuid4().hex[:8]}"
+
+    async with create_mcp_session() as session:
+        response = await session.call_tool(
+            "insert_document_by_id",
+            arguments={
+                **_keyspace(),
+                "document_id": doc_id,
+                "document_content": {"fresh": True},
+                "durability": "NONE",
+                "expiry_seconds": 600,
+            },
+        )
+        payload = extract_payload(response)
+        try:
+            assert payload["success"] is True, payload
+        finally:
+            await _delete(session, doc_id)
+
+
+@pytest.mark.asyncio
+async def test_delete_accepts_durability() -> None:
+    doc_id = f"test_del_{uuid.uuid4().hex[:8]}"
+
+    async with create_mcp_session() as session:
+        await session.call_tool(
+            "upsert_document_by_id",
+            arguments={
+                **_keyspace(),
+                "document_id": doc_id,
+                "document_content": {"doomed": True},
+            },
+        )
+        response = await session.call_tool(
+            "delete_document_by_id",
+            arguments={**_keyspace(), "document_id": doc_id, "durability": "NONE"},
+        )
+        assert extract_payload(response)["success"] is True

--- a/tests/unit/test_kv_write_options.py
+++ b/tests/unit/test_kv_write_options.py
@@ -1,0 +1,230 @@
+"""Unit tests for the durability and expiry options on the KV write tools.
+
+These cover the option-building layer specifically: which SDK option object
+reaches the SDK, and which inputs are rejected before a write is attempted.
+The tools' success/error return paths are covered in test_kv_tools_unit.py.
+"""
+
+from __future__ import annotations
+
+import inspect
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from couchbase.durability import DurabilityLevel, ServerDurability
+
+from cb_mcp.tools.kv import (
+    DURABILITY_LEVELS,
+    delete_document_by_id,
+    insert_document_by_id,
+    replace_document_by_id,
+    upsert_document_by_id,
+)
+
+
+def _make_ctx_with_collection() -> tuple[SimpleNamespace, MagicMock, MagicMock]:
+    """Build a Context plus its underlying cluster + collection mock."""
+    cluster = MagicMock()
+    bucket = MagicMock()
+    collection = MagicMock()
+    bucket.scope.return_value.collection.return_value = collection
+    cluster.bucket.return_value = bucket
+
+    ctx = SimpleNamespace(
+        request_context=SimpleNamespace(
+            lifespan_context=SimpleNamespace(
+                cluster_provider=SimpleNamespace(get_cluster=lambda c: cluster),
+            )
+        )
+    )
+    return ctx, cluster, collection
+
+
+def _options_passed(mock_op: MagicMock) -> dict:
+    """Return the options object handed to a collection op, as a dict."""
+    args = mock_op.call_args.args
+    assert len(args) >= 2, f"expected an options positional arg, got {args!r}"
+    return dict(args[-1])
+
+
+class TestNoOptions:
+    """Omitting every option must reproduce the previous behaviour exactly."""
+
+    def test_upsert_call_shape_is_unchanged(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            result = upsert_document_by_id(ctx, "b", "s", "c", "doc1", {"a": 1})
+
+        assert result == {"success": True}
+        collection.upsert.assert_called_once_with("doc1", {"a": 1})
+
+    def test_insert_call_shape_is_unchanged(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            insert_document_by_id(ctx, "b", "s", "c", "doc1", {"a": 1})
+
+        collection.insert.assert_called_once_with("doc1", {"a": 1})
+
+    def test_replace_call_shape_is_unchanged(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            replace_document_by_id(ctx, "b", "s", "c", "doc1", {"a": 1})
+
+        collection.replace.assert_called_once_with("doc1", {"a": 1})
+
+    def test_delete_call_shape_is_unchanged(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            delete_document_by_id(ctx, "b", "s", "c", "doc1")
+
+        collection.remove.assert_called_once_with("doc1")
+
+
+class TestDurability:
+    def test_uses_the_supported_option_key(self) -> None:
+        """Durability must travel under the ``durability`` key wrapped in
+        ServerDurability. ``durability_level`` is silently dropped by the SDK,
+        which would leave the caller believing in a guarantee they don't have."""
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            result = upsert_document_by_id(
+                ctx, "b", "s", "c", "doc1", {"a": 1}, durability="PERSIST_TO_MAJORITY"
+            )
+
+        assert result["success"] is True
+        options = _options_passed(collection.upsert)
+        assert "durability_level" not in options
+        assert isinstance(options["durability"], ServerDurability)
+        assert options["durability"].level is DurabilityLevel.PERSIST_TO_MAJORITY
+
+    def test_every_documented_level_is_accepted(self) -> None:
+        """The advertised names must all map to the SDK enum. A name in the
+        docstring that the mapping rejects is a broken tool contract."""
+        for name in DURABILITY_LEVELS:
+            ctx, cluster, collection = _make_ctx_with_collection()
+
+            with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+                result = upsert_document_by_id(
+                    ctx, "b", "s", "c", "doc1", {"a": 1}, durability=name
+                )
+
+            assert result["success"] is True, name
+            assert (
+                _options_passed(collection.upsert)["durability"].level
+                is (DURABILITY_LEVELS[name])
+            )
+
+    def test_documented_levels_match_the_docstring(self) -> None:
+        """Guard against the mapping and the docstring drifting apart."""
+        for name in DURABILITY_LEVELS:
+            assert name in upsert_document_by_id.__doc__, name
+
+    def test_unknown_level_is_rejected_before_writing(self) -> None:
+        """An unusable level must fail loudly rather than fall back to writing
+        without the requested guarantee."""
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            result = upsert_document_by_id(
+                ctx, "b", "s", "c", "doc1", {"a": 1}, durability="MAJORITY_ISH"
+            )
+
+        assert result["success"] is False
+        assert "MAJORITY_ISH" in result["error"]
+        collection.upsert.assert_not_called()
+
+    def test_applies_to_delete(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            delete_document_by_id(ctx, "b", "s", "c", "doc1", durability="MAJORITY")
+
+        assert _options_passed(collection.remove)["durability"].level is (
+            DurabilityLevel.MAJORITY
+        )
+
+
+class TestExpiry:
+    def test_becomes_a_timedelta(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            insert_document_by_id(
+                ctx, "b", "s", "c", "doc1", {"a": 1}, expiry_seconds=90
+            )
+
+        assert _options_passed(collection.insert)["expiry"] == timedelta(seconds=90)
+
+    def test_zero_is_sent_rather_than_treated_as_unset(self) -> None:
+        """0 is meaningful - it clears an existing TTL - so it must reach the
+        SDK rather than being folded into "no option given"."""
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            upsert_document_by_id(
+                ctx, "b", "s", "c", "doc1", {"a": 1}, expiry_seconds=0
+            )
+
+        assert _options_passed(collection.upsert)["expiry"] == timedelta(seconds=0)
+
+    def test_negative_is_rejected_before_writing(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            result = upsert_document_by_id(
+                ctx, "b", "s", "c", "doc1", {"a": 1}, expiry_seconds=-1
+            )
+
+        assert result["success"] is False
+        assert "expiry_seconds" in result["error"]
+        collection.upsert.assert_not_called()
+
+    def test_delete_does_not_accept_expiry(self) -> None:
+        """RemoveOptions has no expiry; offering one would be a lie."""
+        assert (
+            "expiry_seconds" not in inspect.signature(delete_document_by_id).parameters
+        )
+
+
+class TestCombined:
+    def test_both_options_reach_the_sdk_together(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            replace_document_by_id(
+                ctx,
+                "b",
+                "s",
+                "c",
+                "doc1",
+                {"a": 1},
+                durability="MAJORITY",
+                expiry_seconds=30,
+            )
+
+        options = _options_passed(collection.replace)
+        assert options["durability"].level is DurabilityLevel.MAJORITY
+        assert options["expiry"] == timedelta(seconds=30)
+
+    def test_durability_failure_is_reported_not_retried(self) -> None:
+        """A write the cluster cannot make durable must surface the failure,
+        never silently succeed at a weaker level."""
+        ctx, cluster, collection = _make_ctx_with_collection()
+        collection.upsert.side_effect = Exception("DurabilityImpossibleException")
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            result = upsert_document_by_id(
+                ctx, "b", "s", "c", "doc1", {"a": 1}, durability="MAJORITY"
+            )
+
+        assert result == {
+            "success": False,
+            "error": "DurabilityImpossibleException",
+        }
+        collection.upsert.assert_called_once()


### PR DESCRIPTION
## Related Issue

Resolves: https://github.com/couchbase/mcp-server-couchbase/issues/270

## What does this change do?

Adds two optional write options to the KV write tools:

- `upsert_document_by_id`, `insert_document_by_id`, `replace_document_by_id`
  gain `durability` and `expiry_seconds`
- `delete_document_by_id` gains `durability`. `RemoveOptions` has no expiry, so
  the parameter is not offered there.

Nothing else changes. No new tool, no change to any return shape, and no
existing test required modification.

One implementation detail deserves attention. Durability travels under the SDK's
`durability` option key, wrapped in `ServerDurability`. The `*Options` classes
are unvalidated `dict` subclasses, so passing `durability_level=` is accepted
and then dropped silently. The write succeeds, the caller is told it succeeded,
and the guarantee they asked for was never requested. A unit test asserts
`durability_level` is absent from the options object so the mistake cannot
return unnoticed.

Invalid durability or expiry is rejected before the write is attempted. A
malformed option can never degrade into an unguarded write.

## Why is this change needed?

Two things an agent could not do at all.

It could not ask for a write to be durable. Every write was acknowledged from
the active node's memory, with no way to request replication or persistence.
For anything an agent writes that a person then acts on, that is the wrong
default to be stuck with.

It could not set a TTL. Agent-created working state had to be cleaned up in a
later turn, or it was left behind permanently.

## Evidence of Testing

Tested at commit `7ca98fe0b3ef99cb4d829b33c9d57483690eda0f`.

**Static checks:**

```
uv run ruff check src/            →  All checks passed
```

`uv run pre-commit run` on the changed files: ruff-lint Passed, ruff-format
Passed, all other hooks Passed.

**Unit tests:**

```
uv run pytest tests/unit -q       →  522 passed
```

New unit tests in `tests/unit/test_kv_write_options.py` cover the option-building
layer. One of them asserts that every durability level named in the docstring is
accepted by the mapping, so the documentation and the code cannot drift apart.

**Integration tests, self-managed Couchbase Server Enterprise 8.0.1, two-node
Docker cluster with one replica:**

```
uv run pytest tests/integration/test_kv_write_options.py \
              tests/integration/test_kv_tools.py \
              tests/integration/test_read_only.py -v    →  41 passed
```

**Integration tests, Couchbase Capella 8.0.2 (AWS us-east-1), travel-sample:**

```
uv run pytest tests/integration/test_kv_write_options.py \
              tests/integration/test_read_only.py -v    →  11 passed
```

**Full suite, against a baseline on unmodified `main`:**

```
main @ 660ade3, untouched   ->  3 failed, 123 passed, 12 skipped   (138 collected)
this branch @ 7ca98fe      ->  3 failed, 129 passed, 12 skipped   (144 collected)
```

The same three failures, the same twelve skips, and the pass count up by exactly
the six tests this branch adds. Both runs are on the same two-node cluster,
minutes apart.

The three failures are `test_fts_tools.py::test_run_fts_query_*`. On this local
cluster the seeded Search index never becomes queryable inside the fixture's
300-second timeout, reporting `query succeeded but returned no rows for the
seeded marker`. They fail before this change and after it, and nothing here
touches Search.

The twelve skips are upstream's own tests declining to assert against an empty
cluster: nine in `test_index_tools.py` because this cluster carries no GSI
indexes, and three in `test_performance_tools.py` because
`system:completed_requests` holds no query of the shape they need. The tests
this PR adds skip nothing, in either environment.

One note for anyone reproducing this. A local cluster whose GSI indexer storage
mode was never set will also fail the three `test_index_tools.py` create and
drop tests with `Please Set Indexer Storage Mode Before Create Index`. That is
the cluster, not this change; `POST /settings/indexes` with `storageMode=plasma`
clears it. It cost us a baseline run, so it is written down here.

Both transcripts and their `--junitxml` output are available on request.

New integration tests in `tests/integration/test_kv_write_options.py` cover what
a live server shows and mocks cannot. A TTL of one second really does expire the
document, polled rather than guessed at, because the server applies expiry
lazily. A `MAJORITY` write is either satisfied by the cluster or refused as
impossible. Both of those are correct answers, so the test asserts that whichever
one occurred is internally consistent: on success the document is read back and
verified, and on refusal the error must be a durability error. What this catches
is the third case, where an option that never reached the server reports plain
success on a cluster that cannot provide the guarantee.

That test deliberately does not inspect the cluster's topology first. An earlier
version did, using a key-value ping to count nodes, and it proved unreliable.
Ping reports the endpoints the SDK currently holds connections to rather than
the cluster's node count, so the same cluster answered 2 in one run and 1 in the
next depending on connection order.

**Environments tested** (both required):

- [x] Couchbase Capella (version: 8.0.2, AWS us-east-1)
- [x] Self-managed Couchbase Server (version: Enterprise 8.0.1, two-node Docker)

**Manual verification:**

Exercised through a scripted MCP client over stdio, built on the official `mcp`
Python SDK, against the two-node self-managed cluster. This is not a GUI client.
MCP Inspector needs Node, which the test machine does not have. The server was
started exactly as a client starts it, and the calls below are real calls with
their real responses.

```
CALL  upsert_document_by_id  (durability=MAJORITY, expiry_seconds=120)
      response : {"success":true}

CALL  get_document_by_id  (reads the durable write back)
      response : {"tool":"manual check","pr":1}

CALL  upsert_document_by_id  (durability="NOT_A_LEVEL")
      response : {"success":false,"error":"durability must be one of
                  ['MAJORITY','MAJORITY_AND_PERSIST_TO_ACTIVE','NONE',
                  'PERSIST_TO_MAJORITY']; got 'NOT_A_LEVEL'"}
```

Read the third call closely. The rejection names the valid levels, and it
happens before any write is attempted, so a mistyped option cannot turn into an
unguarded write.

**Read-only mode:** there are no new tools and no reclassification, so existing
behaviour stands. `tests/integration/test_read_only.py` passed in both
environments as part of the runs above, which covers the write tools staying
filtered out of a read-only session.

## Compatibility Considerations

- **Managed MCP:** no change. Nothing touches `cb_mcp.core`, and the cluster is
  still resolved through `ClusterProvider` via the request context.
- **Tool interfaces:** every addition is optional and defaulted. With no option
  supplied the SDK is called with the same positional signature as before, and
  each tool has a test asserting that.
- **Return shapes:** unchanged.
- **Capella vs self-managed:** identical behaviour, confirmed by running the
  same tests against both. These are data-service KV operations. Durability
  above `NONE` needs enough replicas on either deployment, and the tool surfaces
  the server's refusal instead of quietly downgrading.
- **Dependencies:** none added.
- **`preserve_expiry`:** not included, to keep this PR to one concern. The
  docstrings state the consequence plainly. A full-document write resets expiry,
  so omitting `expiry_seconds` clears an existing TTL. Happy to add
  `preserve_expiry` here if you would prefer it.

## Note on the other PRs against this issue

Issue #270 covers four independent changes. Each PR stands alone and can be
merged, deferred or dropped without reference to the others. All four touch
`src/cb_mcp/tools/kv.py` and the KV table in `README.md` and `DOCKER.md`, so
whichever merges second needs a rebase. That is a textual overlap and not a
dependency: no PR contains another's code, and none documents behaviour that
exists only if another merged. Sequence them however suits you.

## Checklist

- [x] Linked to an issue
- [x] Uses the Couchbase SDK (no REST)
- [x] Works on both Capella and self-managed Couchbase Server
- [x] No changes to `cb_mcp.core` contracts / managed MCP interfaces
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Read-only mode and tool annotations handled. No new tools, and the
      existing classification and annotations are unchanged.
- [x] Evidence of testing included above
- [x] Docs updated (README, DOCKER.md)
- [x] Lint and pre-commit pass. Note that `ruff format --check src/` already
      fails on `main` for a pre-existing lambda in `kv.py`. This PR neither adds
      to that nor fixes it, so the diff stays limited to the change itself.
