### PR TITLE
feat: add CAS-based optimistic concurrency to the KV tools

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -37,13 +37,13 @@ Documentation: <https://docs.couchbase.com/mcp-server/get-started/overview.html>
 
 | Tool Name | Description |
 | --------- | ----------- |
-| `get_document_by_id` | Get a document by ID from a specified scope and collection |
+| `get_document_by_id` | Get a document by ID from a specified scope and collection. Optionally takes `with_cas` to also return the document's revision, for a CAS-guarded write back |
 | `lookup_subdocument` | Look up parts of a document (specific fields, existence checks, or array/object counts) by path without fetching the whole document |
 | `upsert_document_by_id` | Upsert a document by ID to a specified scope and collection. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 | `insert_document_by_id` | Insert a new document by ID (fails if document exists). **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
-| `replace_document_by_id` | Replace an existing document by ID (fails if document doesn't exist). **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
-| `delete_document_by_id` | Delete a document by ID from a specified scope and collection. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
-| `mutate_subdocument` | Modify parts of an existing document (upsert, insert, replace, remove, array ops, counters) by path without rewriting the whole document. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
+| `replace_document_by_id` | Replace an existing document by ID (fails if document doesn't exist). Optionally takes `cas` for optimistic concurrency. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
+| `delete_document_by_id` | Delete a document by ID from a specified scope and collection. Optionally takes `cas` for optimistic concurrency. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
+| `mutate_subdocument` | Modify parts of an existing document (upsert, insert, replace, remove, array ops, counters) by path without rewriting the whole document. Optionally takes `cas` for optimistic concurrency. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 
 ### Query and indexing tools
 

--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ Once the server is connected, you can talk to your Couchbase cluster in natural 
 
 | Tool Name | Description |
 | --------- | ----------- |
-| `get_document_by_id` | Get a document by ID from a specified scope and collection |
+| `get_document_by_id` | Get a document by ID from a specified scope and collection. Optionally takes `with_cas` to also return the document's revision, for a CAS-guarded write back |
 | `lookup_subdocument` | Look up parts of a document (specific fields, existence checks, or array/object counts) by path without fetching the whole document |
 | `upsert_document_by_id` | Upsert a document by ID to a specified scope and collection. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 | `insert_document_by_id` | Insert a new document by ID (fails if document exists). **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
-| `replace_document_by_id` | Replace an existing document by ID (fails if document doesn't exist). **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
-| `delete_document_by_id` | Delete a document by ID from a specified scope and collection. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
-| `mutate_subdocument` | Modify parts of an existing document (upsert, insert, replace, remove, array ops, counters) by path without rewriting the whole document. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
+| `replace_document_by_id` | Replace an existing document by ID (fails if document doesn't exist). Optionally takes `cas` for optimistic concurrency. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
+| `delete_document_by_id` | Delete a document by ID from a specified scope and collection. Optionally takes `cas` for optimistic concurrency. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
+| `mutate_subdocument` | Modify parts of an existing document (upsert, insert, replace, remove, array ops, counters) by path without rewriting the whole document. Optionally takes `cas` for optimistic concurrency. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 
 ### Query and indexing tools
 

--- a/src/cb_mcp/tools/kv.py
+++ b/src/cb_mcp/tools/kv.py
@@ -15,6 +15,7 @@ from typing import Any
 
 import couchbase.subdocument as subdoc
 from couchbase.exceptions import CouchbaseException
+from couchbase.options import MutateInOptions, RemoveOptions, ReplaceOptions
 from fastmcp import Context
 
 from ..utils.connection import connect_to_bucket, format_keyspace
@@ -25,15 +26,60 @@ from ..utils.responses import tool_error, tool_success
 logger = logging.getLogger(f"{MCP_SERVER_NAME}.tools.kv")
 
 
+def _parse_cas(cas: str) -> int:
+    """Parse a CAS value supplied as a decimal string into an int.
+
+    CAS crosses the tool boundary as a *string* because it is an unsigned
+    64-bit value: above 2**53 a JSON number round-trip silently alters it, and
+    a concurrency guard built on an altered CAS is worse than none at all - it
+    would fail against the very revision it was meant to match.
+
+    Validation is strict rather than relying on int(), which would accept
+    "1_0", " 10 " and "+10". Tool parameters are LLM-generated, so a value
+    that looks plausible but means something else is exactly the failure mode
+    worth closing here.
+    """
+    if not isinstance(cas, str) or not cas.isdigit():
+        raise ValueError(
+            "cas must be a decimal string of an unsigned 64-bit integer "
+            f"(digits only); got {cas!r}"
+        )
+    parsed = int(cas)
+    if parsed >= 2**64:
+        raise ValueError(f"cas must fit in an unsigned 64-bit integer; got {parsed}")
+    return parsed
+
+
+def _cas_options(option_cls: Any, cas: str | None) -> Any:
+    """Build an SDK options object carrying a CAS, or None if none is given.
+
+    Returning None when no CAS is requested keeps the call path identical to
+    the one used before this parameter existed, so unguarded writes behave
+    exactly as they did.
+    """
+    if cas is None:
+        return None
+    return option_cls(cas=_parse_cas(cas))
+
+
 def get_document_by_id(
     ctx: Context,
     bucket_name: str,
     scope_name: str,
     collection_name: str,
     document_id: str,
+    with_cas: bool = False,
 ) -> dict[str, Any]:
     """Get a document by its ID from the specified scope and collection.
-    If the document is not found, it will raise an exception."""
+    If the document is not found, it will raise an exception.
+
+    with_cas: leave False (the default) for a plain read, which returns the
+    document itself. Set it to True when you intend to write this document
+    back afterwards: the return value becomes
+    {"content": <document>, "cas": "<revision>"}, and passing that "cas" to
+    replace_document_by_id, delete_document_by_id or mutate_subdocument makes
+    the write fail if anything changed in between, instead of silently
+    discarding the other change."""
 
     keyspace = format_keyspace(bucket_name, scope_name, collection_name)
     cluster = get_cluster_connection(ctx)
@@ -43,7 +89,12 @@ def get_document_by_id(
         collection = bucket.scope(scope_name).collection(collection_name)
         result = collection.get(document_id)
         logger.info(f"Retrieved document from {keyspace}")
-        return result.content_as[dict]
+        content = result.content_as[dict]
+        if not with_cas:
+            return content
+        # Decimal string: CAS is unsigned 64-bit and would not survive a JSON
+        # number round-trip intact above 2**53.
+        return {"content": content, "cas": str(result.cas)}
     except Exception as e:
         logger.error(f"Error getting document from {keyspace}: {e}", exc_info=True)
         raise
@@ -86,18 +137,38 @@ def delete_document_by_id(
     scope_name: str,
     collection_name: str,
     document_id: str,
+    cas: str | None = None,
 ) -> dict[str, Any]:
     """Delete a document by its ID.
 
+    cas: the exact document revision this operation is allowed to act on, as
+    the decimal string returned by get_document_by_id(with_cas=True). If the
+    document has changed since that read, the operation FAILS instead of
+    overwriting the newer revision. Use this for any read-modify-write: read
+    with with_cas=True, decide what to change, then write back with the cas
+    you were given. Omit it to act unconditionally.
+    Use it whenever the decision to delete was based on document content you
+    read earlier.
+
     Returns {"success": True} on success, or {"success": False, "error": "..."} on
-    failure with the reason (e.g. document not found, permission denied, network error)."""
+    failure with the reason (e.g. document not found, the document changed since the
+    cas you supplied, permission denied, network error)."""
     keyspace = format_keyspace(bucket_name, scope_name, collection_name)
+    try:
+        options = _cas_options(RemoveOptions, cas)
+    except ValueError as e:
+        logger.warning(f"Invalid delete options for {keyspace}: {e}")
+        return tool_error(e)
+
     cluster = get_cluster_connection(ctx)
     bucket = connect_to_bucket(cluster, bucket_name)
     try:
         logger.debug(f"Deleting document from {keyspace}")
         collection = bucket.scope(scope_name).collection(collection_name)
-        collection.remove(document_id)
+        if options is None:
+            collection.remove(document_id)
+        else:
+            collection.remove(document_id, options)
         logger.info(f"Successfully deleted document from {keyspace}")
         return tool_success()
     except Exception as e:
@@ -141,21 +212,39 @@ def replace_document_by_id(
     collection_name: str,
     document_id: str,
     document_content: dict[str, Any],
+    cas: str | None = None,
 ) -> dict[str, Any]:
     """Replace an existing document by its ID. This operation will FAIL if the document does not exist.
 
     IMPORTANT: If this operation fails, DO NOT automatically try insert or upsert.
     Report the failure to the user. They can choose to 'insert' or 'upsert' if desired.
 
+    cas: the exact document revision this operation is allowed to act on, as
+    the decimal string returned by get_document_by_id(with_cas=True). If the
+    document has changed since that read, the operation FAILS instead of
+    overwriting the newer revision. Use this for any read-modify-write: read
+    with with_cas=True, decide what to change, then write back with the cas
+    you were given. Omit it to act unconditionally.
+
     Returns {"success": True} on success, or {"success": False, "error": "..."} on
-    failure with the reason (e.g. document does not exist, permission denied, network error)."""
+    failure with the reason (e.g. document does not exist, the document changed since
+    the cas you supplied, permission denied, network error)."""
     keyspace = format_keyspace(bucket_name, scope_name, collection_name)
+    try:
+        options = _cas_options(ReplaceOptions, cas)
+    except ValueError as e:
+        logger.warning(f"Invalid replace options for {keyspace}: {e}")
+        return tool_error(e)
+
     cluster = get_cluster_connection(ctx)
     bucket = connect_to_bucket(cluster, bucket_name)
     try:
         logger.debug(f"Replacing document in {keyspace}")
         collection = bucket.scope(scope_name).collection(collection_name)
-        collection.replace(document_id, document_content)
+        if options is None:
+            collection.replace(document_id, document_content)
+        else:
+            collection.replace(document_id, document_content, options)
         logger.info(f"Successfully replaced document in {keyspace}")
         return tool_success()
     except Exception as e:
@@ -270,6 +359,52 @@ def lookup_subdocument(
     return response
 
 
+def _mutate_in_response(
+    result: Any,
+    spec_meta: list[tuple[str, str]],
+    keyspace: str,
+) -> dict[str, Any]:
+    """Build the per-category path -> outcome mapping for a committed mutate_in.
+
+    Extracted from mutate_subdocument unchanged. Adding the cas parameter
+    pushed that function past the project's configured branch and statement
+    limits; lifting this block out is what brings it back under them.
+    """
+    response: dict[str, Any] = {}
+    for index, (op, path) in enumerate(spec_meta):
+        bucket_for_op = response.setdefault(op, {})
+        if op != "counter":
+            bucket_for_op[path] = {"success": True}
+            continue
+
+        # The installed SDK constructs MutateInResult without a transcoder
+        # (unlike LookupInResult), which makes content_as always raise for
+        # mutate_in results — fall back to decoding the raw field value.
+        new_value = None
+        for read_new_value in (
+            lambda index=index: result.content_as[int](index),
+            lambda index=index: int(
+                json.loads(result._orig.raw_result["fields"][index]["value"])
+            ),
+        ):
+            try:
+                new_value = read_new_value()
+                break
+            except Exception:  # noqa: S112 (expected fallback attempt, not a swallowed bug)
+                continue
+
+        if new_value is None:
+            logger.warning(
+                f"Counter mutation at '{path}' in {keyspace} committed but "
+                "its new value could not be read from the SDK result."
+            )
+            bucket_for_op[path] = {"success": True}
+            continue
+        bucket_for_op[path] = {"success": True, "value": new_value}
+
+    return response
+
+
 def mutate_subdocument(
     ctx: Context,
     bucket_name: str,
@@ -286,6 +421,7 @@ def mutate_subdocument(
     array_add_unique_specs: list[dict[str, Any]] | None = None,
     counter_specs: list[dict[str, Any]] | None = None,
     create_parents: bool = False,
+    cas: str | None = None,
 ) -> dict[str, Any]:
     """Modify parts of an EXISTING document without rewriting the whole thing, using
     Couchbase sub-document mutation operations. The document must already exist — use
@@ -324,6 +460,12 @@ def mutate_subdocument(
     create_parents: if True, missing intermediate path segments are created automatically
     for every category except replace_specs and remove_paths, which always require the full
     path to already exist.
+
+    cas: the exact document revision these mutations are allowed to apply to, as the
+    decimal string returned by get_document_by_id(with_cas=True). If the document has
+    changed since that read, the whole call FAILS rather than applying mutations on top
+    of a revision you never saw. Use it for any read-modify-write; omit it to mutate
+    unconditionally.
 
     At least one spec must be provided. As a rule of thumb, keep the combined number of
     specs across all categories to 16 or fewer — Couchbase limits subdocument operations
@@ -397,12 +539,12 @@ def mutate_subdocument(
         (
             "counter",
             counter_specs or [],
-            lambda s: subdoc.increment(
-                s["path"], s["delta"], create_parents=create_parents
-            )
-            if s["delta"] >= 0
-            else subdoc.decrement(
-                s["path"], abs(s["delta"]), create_parents=create_parents
+            lambda s: (
+                subdoc.increment(s["path"], s["delta"], create_parents=create_parents)
+                if s["delta"] >= 0
+                else subdoc.decrement(
+                    s["path"], abs(s["delta"]), create_parents=create_parents
+                )
             ),
         ),
     ]
@@ -425,13 +567,22 @@ def mutate_subdocument(
         logger.warning(f"Error performing sub-document mutation in {keyspace}: {error}")
         return {"error": error}
 
+    try:
+        options = _cas_options(MutateInOptions, cas)
+    except ValueError as e:
+        logger.warning(f"Invalid sub-document mutation options for {keyspace}: {e}")
+        return {"error": str(e)}
+
     cluster = get_cluster_connection(ctx)
     bucket = connect_to_bucket(cluster, bucket_name)
 
     try:
         logger.debug(f"Performing sub-document mutation in {keyspace}")
         collection = bucket.scope(scope_name).collection(collection_name)
-        result = collection.mutate_in(document_id, specs)
+        if options is None:
+            result = collection.mutate_in(document_id, specs)
+        else:
+            result = collection.mutate_in(document_id, specs, options)
     except Exception as e:
         error_context = getattr(e, "error_context", None)
         failed_index = getattr(error_context, "first_error_index", None)
@@ -444,36 +595,6 @@ def mutate_subdocument(
         )
         return {"error": f"{e}{detail}"}
 
-    response: dict[str, Any] = {}
-    for index, (op, path) in enumerate(spec_meta):
-        bucket_for_op = response.setdefault(op, {})
-        if op == "counter":
-            # The installed SDK constructs MutateInResult without a transcoder
-            # (unlike LookupInResult), which makes content_as always raise for
-            # mutate_in results — fall back to decoding the raw field value.
-            new_value = None
-            for read_new_value in (
-                lambda index=index: result.content_as[int](index),
-                lambda index=index: int(
-                    json.loads(result._orig.raw_result["fields"][index]["value"])
-                ),
-            ):
-                try:
-                    new_value = read_new_value()
-                    break
-                except Exception:  # noqa: S112 (expected fallback attempt, not a swallowed bug)
-                    continue
-
-            if new_value is None:
-                logger.warning(
-                    f"Counter mutation at '{path}' in {keyspace} committed but "
-                    "its new value could not be read from the SDK result."
-                )
-                bucket_for_op[path] = {"success": True}
-                continue
-            bucket_for_op[path] = {"success": True, "value": new_value}
-            continue
-        bucket_for_op[path] = {"success": True}
-
+    response = _mutate_in_response(result, spec_meta, keyspace)
     logger.info(f"Successfully performed sub-document mutation in {keyspace}")
     return response

--- a/tests/integration/test_kv_optimistic_concurrency.py
+++ b/tests/integration/test_kv_optimistic_concurrency.py
@@ -1,0 +1,278 @@
+"""
+Integration tests for CAS-based optimistic concurrency.
+
+The behaviour worth proving against a live server is not that the parameter is
+accepted, but that it is *enforced*: a write carrying a superseded revision
+must fail, and the concurrent update it would have destroyed must survive.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from conftest import (
+    create_mcp_session,
+    extract_payload,
+    get_test_collection,
+    get_test_scope,
+    require_test_bucket,
+)
+
+
+def _keyspace() -> dict[str, str]:
+    return {
+        "bucket_name": require_test_bucket(),
+        "scope_name": get_test_scope(),
+        "collection_name": get_test_collection(),
+    }
+
+
+async def _seed(session, content: dict) -> str:
+    doc_id = f"test_cas_{uuid.uuid4().hex[:8]}"
+    await session.call_tool(
+        "upsert_document_by_id",
+        arguments={
+            **_keyspace(),
+            "document_id": doc_id,
+            "document_content": content,
+        },
+    )
+    return doc_id
+
+
+async def _read_with_cas(session, doc_id: str) -> dict:
+    response = await session.call_tool(
+        "get_document_by_id",
+        arguments={**_keyspace(), "document_id": doc_id, "with_cas": True},
+    )
+    return extract_payload(response)
+
+
+async def _read(session, doc_id: str) -> dict:
+    response = await session.call_tool(
+        "get_document_by_id",
+        arguments={**_keyspace(), "document_id": doc_id},
+    )
+    return extract_payload(response)
+
+
+async def _delete(session, doc_id: str) -> None:
+    await session.call_tool(
+        "delete_document_by_id",
+        arguments={**_keyspace(), "document_id": doc_id},
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_read_returns_the_bare_document() -> None:
+    """Existing callers must see no change."""
+    async with create_mcp_session() as session:
+        doc_id = await _seed(session, {"name": "unchanged", "value": 1})
+        try:
+            assert await _read(session, doc_id) == {"name": "unchanged", "value": 1}
+        finally:
+            await _delete(session, doc_id)
+
+
+@pytest.mark.asyncio
+async def test_with_cas_returns_content_and_a_usable_cas() -> None:
+    async with create_mcp_session() as session:
+        doc_id = await _seed(session, {"name": "enveloped", "value": 2})
+        try:
+            payload = await _read_with_cas(session, doc_id)
+            assert payload["content"] == {"name": "enveloped", "value": 2}
+            assert payload["cas"].isdigit(), (
+                f"expected a decimal CAS string, got {payload['cas']!r}"
+            )
+            assert int(payload["cas"]) > 0
+        finally:
+            await _delete(session, doc_id)
+
+
+@pytest.mark.asyncio
+async def test_cas_changes_when_the_document_is_rewritten() -> None:
+    """A CAS that did not track the revision would be useless as a guard."""
+    async with create_mcp_session() as session:
+        doc_id = await _seed(session, {"version": 1})
+        try:
+            first = await _read_with_cas(session, doc_id)
+            await session.call_tool(
+                "upsert_document_by_id",
+                arguments={
+                    **_keyspace(),
+                    "document_id": doc_id,
+                    "document_content": {"version": 2},
+                },
+            )
+            second = await _read_with_cas(session, doc_id)
+            assert second["cas"] != first["cas"]
+        finally:
+            await _delete(session, doc_id)
+
+
+@pytest.mark.asyncio
+async def test_replace_with_current_cas_succeeds() -> None:
+    async with create_mcp_session() as session:
+        doc_id = await _seed(session, {"version": 1})
+        try:
+            current = await _read_with_cas(session, doc_id)
+            response = await session.call_tool(
+                "replace_document_by_id",
+                arguments={
+                    **_keyspace(),
+                    "document_id": doc_id,
+                    "document_content": {"version": 2},
+                    "cas": current["cas"],
+                },
+            )
+            payload = extract_payload(response)
+            assert payload["success"] is True, (
+                f"replace with the current CAS should succeed, got {payload}"
+            )
+            assert await _read(session, doc_id) == {"version": 2}
+        finally:
+            await _delete(session, doc_id)
+
+
+@pytest.mark.asyncio
+async def test_replace_with_stale_cas_fails_and_preserves_the_other_write() -> None:
+    """The whole point of the guard. Without it the concurrent update is lost
+    silently, which is the failure this feature exists to prevent."""
+    async with create_mcp_session() as session:
+        doc_id = await _seed(session, {"version": 1})
+        try:
+            stale = await _read_with_cas(session, doc_id)
+
+            # Someone else moves the document on.
+            await session.call_tool(
+                "upsert_document_by_id",
+                arguments={
+                    **_keyspace(),
+                    "document_id": doc_id,
+                    "document_content": {"version": 2},
+                },
+            )
+
+            response = await session.call_tool(
+                "replace_document_by_id",
+                arguments={
+                    **_keyspace(),
+                    "document_id": doc_id,
+                    "document_content": {"version": 3},
+                    "cas": stale["cas"],
+                },
+            )
+            assert extract_payload(response)["success"] is False, (
+                "replace with a stale CAS must fail"
+            )
+
+            surviving = await _read(session, doc_id)
+            assert surviving == {"version": 2}, (
+                f"the concurrent write must survive, got {surviving}"
+            )
+        finally:
+            await _delete(session, doc_id)
+
+
+@pytest.mark.asyncio
+async def test_delete_with_stale_cas_fails_and_document_survives() -> None:
+    async with create_mcp_session() as session:
+        doc_id = await _seed(session, {"version": 1})
+        try:
+            stale = await _read_with_cas(session, doc_id)
+            await session.call_tool(
+                "upsert_document_by_id",
+                arguments={
+                    **_keyspace(),
+                    "document_id": doc_id,
+                    "document_content": {"version": 2},
+                },
+            )
+
+            response = await session.call_tool(
+                "delete_document_by_id",
+                arguments={
+                    **_keyspace(),
+                    "document_id": doc_id,
+                    "cas": stale["cas"],
+                },
+            )
+            assert extract_payload(response)["success"] is False
+
+            assert await _read(session, doc_id) == {"version": 2}
+        finally:
+            await _delete(session, doc_id)
+
+
+@pytest.mark.asyncio
+async def test_mutate_subdocument_with_stale_cas_fails() -> None:
+    async with create_mcp_session() as session:
+        doc_id = await _seed(session, {"counter": 1})
+        try:
+            stale = await _read_with_cas(session, doc_id)
+            await session.call_tool(
+                "upsert_document_by_id",
+                arguments={
+                    **_keyspace(),
+                    "document_id": doc_id,
+                    "document_content": {"counter": 2},
+                },
+            )
+
+            response = await session.call_tool(
+                "mutate_subdocument",
+                arguments={
+                    **_keyspace(),
+                    "document_id": doc_id,
+                    "upsert_specs": [{"path": "counter", "value": 3}],
+                    "cas": stale["cas"],
+                },
+            )
+            assert "error" in extract_payload(response)
+            assert await _read(session, doc_id) == {"counter": 2}
+        finally:
+            await _delete(session, doc_id)
+
+
+@pytest.mark.asyncio
+async def test_mutate_subdocument_with_current_cas_succeeds() -> None:
+    async with create_mcp_session() as session:
+        doc_id = await _seed(session, {"counter": 1})
+        try:
+            current = await _read_with_cas(session, doc_id)
+            response = await session.call_tool(
+                "mutate_subdocument",
+                arguments={
+                    **_keyspace(),
+                    "document_id": doc_id,
+                    "upsert_specs": [{"path": "counter", "value": 3}],
+                    "cas": current["cas"],
+                },
+            )
+            payload = extract_payload(response)
+            assert payload["upsert"]["counter"] == {"success": True}, payload
+        finally:
+            await _delete(session, doc_id)
+
+
+@pytest.mark.asyncio
+async def test_malformed_cas_is_rejected_and_nothing_is_written() -> None:
+    async with create_mcp_session() as session:
+        doc_id = await _seed(session, {"version": 1})
+        try:
+            response = await session.call_tool(
+                "replace_document_by_id",
+                arguments={
+                    **_keyspace(),
+                    "document_id": doc_id,
+                    "document_content": {"version": 99},
+                    "cas": "not-a-number",
+                },
+            )
+            payload = extract_payload(response)
+            assert payload["success"] is False
+            assert "cas" in payload["error"]
+            assert await _read(session, doc_id) == {"version": 1}
+        finally:
+            await _delete(session, doc_id)

--- a/tests/unit/test_kv_optimistic_concurrency.py
+++ b/tests/unit/test_kv_optimistic_concurrency.py
@@ -1,0 +1,229 @@
+"""Unit tests for the CAS-based optimistic concurrency parameters.
+
+Covers the parse-and-build layer: which CAS reaches the SDK, and which values
+are rejected before any write is attempted.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cb_mcp.tools.kv import (
+    _parse_cas,
+    delete_document_by_id,
+    get_document_by_id,
+    mutate_subdocument,
+    replace_document_by_id,
+)
+
+
+def _make_ctx_with_collection() -> tuple[SimpleNamespace, MagicMock, MagicMock]:
+    """Build a Context plus its underlying cluster + collection mock."""
+    cluster = MagicMock()
+    bucket = MagicMock()
+    collection = MagicMock()
+    bucket.scope.return_value.collection.return_value = collection
+    cluster.bucket.return_value = bucket
+
+    ctx = SimpleNamespace(
+        request_context=SimpleNamespace(
+            lifespan_context=SimpleNamespace(
+                cluster_provider=SimpleNamespace(get_cluster=lambda c: cluster),
+            )
+        )
+    )
+    return ctx, cluster, collection
+
+
+def _options_passed(mock_op: MagicMock) -> dict:
+    args = mock_op.call_args.args
+    assert len(args) >= 2, f"expected an options positional arg, got {args!r}"
+    return dict(args[-1])
+
+
+def _program_get(collection: MagicMock, content: dict, cas: int) -> None:
+    document = MagicMock()
+    document.content_as = {dict: content}
+    document.cas = cas
+    collection.get.return_value = document
+
+
+class TestParseCas:
+    """CAS is unsigned 64-bit and arrives as an LLM-generated string."""
+
+    def test_accepts_a_plain_decimal_string(self) -> None:
+        assert _parse_cas("12345") == 12345
+
+    def test_accepts_values_above_2_to_the_53(self) -> None:
+        """The reason CAS is a string at all: these do not survive JSON."""
+        big = 2**63 + 12345
+        assert _parse_cas(str(big)) == big
+
+    @pytest.mark.parametrize(
+        "value", ["1_0", " 10 ", "+10", "-1", "0x10", "", "abc", "1.0"]
+    )
+    def test_rejects_anything_that_is_not_digits(self, value: str) -> None:
+        """int() would silently accept several of these as a different number,
+        which for a concurrency guard means matching the wrong revision."""
+        with pytest.raises(ValueError):
+            _parse_cas(value)
+
+    def test_rejects_values_too_large_for_64_bits(self) -> None:
+        with pytest.raises(ValueError):
+            _parse_cas(str(2**64))
+
+
+class TestGetWithCas:
+    def test_default_return_shape_is_unchanged(self) -> None:
+        """Existing callers must see exactly the bare document."""
+        ctx, cluster, collection = _make_ctx_with_collection()
+        _program_get(collection, {"a": 1}, 12345)
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            result = get_document_by_id(ctx, "b", "s", "c", "doc1")
+
+        assert result == {"a": 1}
+
+    def test_with_cas_returns_content_and_cas(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+        _program_get(collection, {"a": 1}, 12345)
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            result = get_document_by_id(ctx, "b", "s", "c", "doc1", with_cas=True)
+
+        assert result == {"content": {"a": 1}, "cas": "12345"}
+
+    def test_large_cas_survives_the_round_trip(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+        big = 2**63 + 12345
+        _program_get(collection, {"a": 1}, big)
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            result = get_document_by_id(ctx, "b", "s", "c", "doc1", with_cas=True)
+
+        assert _parse_cas(result["cas"]) == big
+
+    def test_missing_document_still_raises(self) -> None:
+        """with_cas must not change the not-found contract."""
+        ctx, cluster, collection = _make_ctx_with_collection()
+        collection.get.side_effect = Exception("DocumentNotFoundException")
+
+        with (
+            patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster),
+            pytest.raises(Exception, match="DocumentNotFoundException"),
+        ):
+            get_document_by_id(ctx, "b", "s", "c", "doc1", with_cas=True)
+
+
+class TestRoundTrip:
+    """The CAS a read hands out must be the CAS a write accepts."""
+
+    def test_cas_from_get_is_usable_by_replace(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+        _program_get(collection, {"a": 1}, 987654321)
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            read = get_document_by_id(ctx, "b", "s", "c", "doc1", with_cas=True)
+            replace_document_by_id(
+                ctx, "b", "s", "c", "doc1", {"a": 2}, cas=read["cas"]
+            )
+
+        assert _options_passed(collection.replace)["cas"] == 987654321
+
+
+class TestCasOnWrites:
+    def test_replace_without_cas_preserves_call_shape(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            replace_document_by_id(ctx, "b", "s", "c", "doc1", {"a": 1})
+
+        collection.replace.assert_called_once_with("doc1", {"a": 1})
+
+    def test_delete_without_cas_preserves_call_shape(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            delete_document_by_id(ctx, "b", "s", "c", "doc1")
+
+        collection.remove.assert_called_once_with("doc1")
+
+    def test_delete_passes_cas(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            result = delete_document_by_id(ctx, "b", "s", "c", "doc1", cas="42")
+
+        assert result == {"success": True}
+        assert _options_passed(collection.remove)["cas"] == 42
+
+    def test_mutate_subdocument_passes_cas(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            mutate_subdocument(
+                ctx,
+                "b",
+                "s",
+                "c",
+                "doc1",
+                upsert_specs=[{"path": "a", "value": 1}],
+                cas="42",
+            )
+
+        assert _options_passed(collection.mutate_in)["cas"] == 42
+
+    def test_mutate_subdocument_without_cas_preserves_call_shape(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            mutate_subdocument(
+                ctx, "b", "s", "c", "doc1", upsert_specs=[{"path": "a", "value": 1}]
+            )
+
+        assert len(collection.mutate_in.call_args.args) == 2
+
+
+class TestRejectionBeforeWriting:
+    """A malformed CAS must never degrade into an unguarded write."""
+
+    def test_replace(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            result = replace_document_by_id(
+                ctx, "b", "s", "c", "doc1", {"a": 1}, cas="not-a-number"
+            )
+
+        assert result["success"] is False
+        assert "cas" in result["error"]
+        collection.replace.assert_not_called()
+
+    def test_delete(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            result = delete_document_by_id(ctx, "b", "s", "c", "doc1", cas="1_0")
+
+        assert result["success"] is False
+        collection.remove.assert_not_called()
+
+    def test_mutate_subdocument(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            result = mutate_subdocument(
+                ctx,
+                "b",
+                "s",
+                "c",
+                "doc1",
+                upsert_specs=[{"path": "a", "value": 1}],
+                cas="abc",
+            )
+
+        assert "cas" in result["error"]
+        collection.mutate_in.assert_not_called()


### PR DESCRIPTION
## Related Issue

Resolves: https://github.com/couchbase/mcp-server-couchbase/issues/270

## What does this change do?

Adds CAS-based optimistic concurrency across the KV tools as one unit:

- `get_document_by_id` gains `with_cas`, defaulting to `False`. When `False` the
  return value is byte-for-byte what it was. When `True` it returns
  `{"content": <document>, "cas": "<revision>"}`.
- `replace_document_by_id`, `delete_document_by_id` and `mutate_subdocument`
  gain an optional `cas`.

The read and the writes ship together on purpose. Split apart, either half
documents a workflow only the other half makes possible, and a docstring telling
an LLM to pass a CAS to a tool that does not accept one is worse than no feature
at all.

CAS crosses the tool boundary as a decimal string because it is an unsigned
64-bit value. Above 2^53 a JSON number round-trip alters it silently, and a
guard built on an altered CAS fails against the very revision it was meant to
match. Parsing accepts digits only. `int()` would take `"1_0"`, `" 10 "` and
`"+10"` as different numbers, and tool parameters are LLM-generated, so a value
that looks plausible but means something else is the failure worth closing.

A malformed CAS is rejected before the write is attempted.

## Why is this change needed?

An agent that reads a document, reasons about the contents, and writes an
updated version had no way to do that safely. The CAS needed to guard the write
was never exposed, so the only available behaviour was a blind overwrite of
whatever the current revision happened to be. With an LLM in the loop the
read-to-write window is seconds to minutes, which makes losing a concurrent
update a routine outcome and not a narrow race.

`with_cas` is opt-in so the default return shape stays exactly as it was. A
plain read is the common case and gains nothing from an envelope.

## Evidence of Testing

Tested at commit `ae8e6bcf9acde442460fdbd020194e3d7740b44e`.

**Static checks:**

```
uv run ruff check src/            →  All checks passed
```

**Unit tests:**

```
uv run pytest tests/unit -q       →  531 passed
```

New unit tests in `tests/unit/test_kv_optimistic_concurrency.py` cover CAS
parsing, including the values `int()` would misread, the unchanged default
return shape, and a round-trip asserting the CAS a read hands out is the CAS a
write accepts.

**Integration tests, self-managed Couchbase Server Enterprise 8.0.1, two-node
Docker cluster with one replica:**

```
uv run pytest tests/integration/test_kv_optimistic_concurrency.py \
              tests/integration/test_kv_tools.py \
              tests/integration/test_read_only.py -v    →  44 passed
```

**Integration tests, Couchbase Capella 8.0.2 (AWS us-east-1), travel-sample:**

```
uv run pytest tests/integration/test_kv_optimistic_concurrency.py \
              tests/integration/test_read_only.py -v    →  14 passed
```

**Full suite, against a baseline on unmodified `main`:**

```
main @ 660ade3, untouched   ->  3 failed, 123 passed, 12 skipped   (138 collected)
this branch @ ae8e6bc      ->  3 failed, 132 passed, 12 skipped   (147 collected)
```

The same three failures, the same twelve skips, and the pass count up by exactly
the nine tests this branch adds. Both runs are on the same two-node cluster,
minutes apart.

The three failures are `test_fts_tools.py::test_run_fts_query_*`. On this local
cluster the seeded Search index never becomes queryable inside the fixture's
300-second timeout, reporting `query succeeded but returned no rows for the
seeded marker`. They fail before this change and after it, and nothing here
touches Search.

The twelve skips are upstream's own tests declining to assert against an empty
cluster: nine in `test_index_tools.py` because this cluster carries no GSI
indexes, and three in `test_performance_tools.py` because
`system:completed_requests` holds no query of the shape they need. The tests
this PR adds skip nothing, in either environment.

One note for anyone reproducing this. A local cluster whose GSI indexer storage
mode was never set will also fail the three `test_index_tools.py` create and
drop tests with `Please Set Indexer Storage Mode Before Create Index`. That is
the cluster, not this change; `POST /settings/indexes` with `storageMode=plasma`
clears it. It cost us a baseline run, so it is written down here.

Both transcripts and their `--junitxml` output are available on request.

The negative cases in `tests/integration/test_kv_optimistic_concurrency.py`
carry the weight. A stale-CAS replace must fail, and the concurrent write must
survive, with the same for delete and for `mutate_subdocument`. That surviving
write is the behaviour this feature exists to produce.

**Environments tested** (both required):

- [x] Couchbase Capella (version: 8.0.2, AWS us-east-1)
- [x] Self-managed Couchbase Server (version: Enterprise 8.0.1, two-node Docker)

**Manual verification:**

Exercised through a scripted MCP client over stdio, built on the official `mcp`
Python SDK, against the two-node self-managed cluster. Real calls, real
responses:

```
CALL  get_document_by_id  (with_cas=True)
      response : {"content":{"tool":"manual check","pr":2},
                  "cas":"1789235505816010752"}

CALL  replace_document_by_id  (cas=1789235505816010752)
      response : {"success":true}

CALL  replace_document_by_id  (same cas, now stale)
      response : {"success":false,"error":"CasMismatchException(<ec=9,
                  category=couchbase.common, message=Operation failed, ...
                  'key': 'manual_check_bb645f1f', ...>)"}
```

The three calls together are the whole feature. A revision is handed out, it
guards one write successfully, and the same value is refused once that write has
moved it. Note the CAS is a 19-digit decimal string, which is the reason it does
not cross the boundary as a JSON number.

**Read-only mode:** no new tools and no reclassification. The write tools stay
in `WRITE_TOOLS` and `get_document_by_id` stays read-only.
`tests/integration/test_read_only.py` passed in both environments as part of the
runs above.

## Compatibility Considerations

- **Managed MCP:** no change. Nothing touches `cb_mcp.core`.
- **Tool interfaces:** every addition is optional and defaulted.
- **Return shapes:** `get_document_by_id` keeps its existing return value, which
  is why `with_cas` is opt-in. The enveloped shape appears only when explicitly
  requested, and a test asserts the default. The write tools' return shapes are
  untouched.
- **Capella vs self-managed:** identical behaviour, confirmed by running the
  same tests against both. `result.cas` comes from the same data-service `get`
  already in use.
- **Dependencies:** none added.
- **`_mutate_in_response`:** extracted from `mutate_subdocument` with its
  behaviour unchanged. Adding the parameter pushed that function past this
  project's configured branch and statement limits, so the extraction is what
  makes the change possible. It also leaves `ruff format --check src/` passing,
  which currently fails on `main`.

## Note on the other PRs against this issue

Issue #270 covers four independent changes. Each stands alone. All four touch
`src/cb_mcp/tools/kv.py` and the KV table in the docs, so whichever merges
second needs a rebase. That is a textual overlap and not a dependency: no PR
contains another's code, and none documents behaviour that exists only if
another merged.

## Checklist

- [x] Linked to an issue
- [x] Uses the Couchbase SDK (no REST)
- [x] Works on both Capella and self-managed Couchbase Server
- [x] No changes to `cb_mcp.core` contracts / managed MCP interfaces
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Read-only mode and tool annotations handled. No new tools; the write tools
      stay in `WRITE_TOOLS` and `get_document_by_id` stays read-only.
- [x] Evidence of testing included above
- [x] Docs updated (README, DOCKER.md)
- [x] Lint and pre-commit pass
