### PR TITLE
feat: add store_semantics to mutate_subdocument

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -43,7 +43,7 @@ Documentation: <https://docs.couchbase.com/mcp-server/get-started/overview.html>
 | `insert_document_by_id` | Insert a new document by ID (fails if document exists). **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 | `replace_document_by_id` | Replace an existing document by ID (fails if document doesn't exist). **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 | `delete_document_by_id` | Delete a document by ID from a specified scope and collection. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
-| `mutate_subdocument` | Modify parts of an existing document (upsert, insert, replace, remove, array ops, counters) by path without rewriting the whole document. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
+| `mutate_subdocument` | Modify parts of an existing document (upsert, insert, replace, remove, array ops, counters) by path without rewriting the whole document. Optionally takes `store_semantics` to create the document when it is missing. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 
 ### Query and indexing tools
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Once the server is connected, you can talk to your Couchbase cluster in natural 
 | `insert_document_by_id` | Insert a new document by ID (fails if document exists). **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 | `replace_document_by_id` | Replace an existing document by ID (fails if document doesn't exist). **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 | `delete_document_by_id` | Delete a document by ID from a specified scope and collection. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
-| `mutate_subdocument` | Modify parts of an existing document (upsert, insert, replace, remove, array ops, counters) by path without rewriting the whole document. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
+| `mutate_subdocument` | Modify parts of an existing document (upsert, insert, replace, remove, array ops, counters) by path without rewriting the whole document. Optionally takes `store_semantics` to create the document when it is missing. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 
 ### Query and indexing tools
 

--- a/src/cb_mcp/tools/kv.py
+++ b/src/cb_mcp/tools/kv.py
@@ -15,6 +15,8 @@ from typing import Any
 
 import couchbase.subdocument as subdoc
 from couchbase.exceptions import CouchbaseException
+from couchbase.options import MutateInOptions
+from couchbase.subdocument import StoreSemantics
 from fastmcp import Context
 
 from ..utils.connection import connect_to_bucket, format_keyspace
@@ -23,6 +25,15 @@ from ..utils.context import get_cluster_connection
 from ..utils.responses import tool_error, tool_success
 
 logger = logging.getLogger(f"{MCP_SERVER_NAME}.tools.kv")
+
+# Store semantics accepted by mutate_subdocument, mapped to the SDK enum.
+# Exposed as strings because MCP tool parameters are JSON-typed and
+# LLM-generated; the mapping doubles as input validation.
+STORE_SEMANTICS: dict[str, StoreSemantics] = {
+    "REPLACE": StoreSemantics.REPLACE,
+    "UPSERT": StoreSemantics.UPSERT,
+    "INSERT": StoreSemantics.INSERT,
+}
 
 
 def get_document_by_id(
@@ -270,6 +281,70 @@ def lookup_subdocument(
     return response
 
 
+def _mutate_in_response(
+    result: Any,
+    spec_meta: list[tuple[str, str]],
+    keyspace: str,
+) -> dict[str, Any]:
+    """Build the per-category path -> outcome mapping for a committed mutate_in.
+
+    Extracted from mutate_subdocument unchanged. Adding the store_semantics
+    parameter pushed that function past the project's configured branch and
+    statement limits; lifting this block out is what brings it back under them.
+    """
+    response: dict[str, Any] = {}
+    for index, (op, path) in enumerate(spec_meta):
+        bucket_for_op = response.setdefault(op, {})
+        if op != "counter":
+            bucket_for_op[path] = {"success": True}
+            continue
+
+        # The installed SDK constructs MutateInResult without a transcoder
+        # (unlike LookupInResult), which makes content_as always raise for
+        # mutate_in results — fall back to decoding the raw field value.
+        new_value = None
+        for read_new_value in (
+            lambda index=index: result.content_as[int](index),
+            lambda index=index: int(
+                json.loads(result._orig.raw_result["fields"][index]["value"])
+            ),
+        ):
+            try:
+                new_value = read_new_value()
+                break
+            except Exception:  # noqa: S112 (expected fallback attempt, not a swallowed bug)
+                continue
+
+        if new_value is None:
+            logger.warning(
+                f"Counter mutation at '{path}' in {keyspace} committed but "
+                "its new value could not be read from the SDK result."
+            )
+            bucket_for_op[path] = {"success": True}
+            continue
+        bucket_for_op[path] = {"success": True, "value": new_value}
+
+    return response
+
+
+def _store_semantics_options(store_semantics: str | None) -> MutateInOptions | None:
+    """Build MutateInOptions carrying store semantics, or None if unset.
+
+    Returning None when nothing is requested keeps the call path identical to
+    the one used before this parameter existed, so the default behaviour -
+    failing when the document is missing - is untouched.
+    """
+    if store_semantics is None:
+        return None
+    semantics = STORE_SEMANTICS.get(store_semantics)
+    if semantics is None:
+        raise ValueError(
+            f"store_semantics must be one of {sorted(STORE_SEMANTICS)}; "
+            f"got {store_semantics!r}"
+        )
+    return MutateInOptions(store_semantics=semantics)
+
+
 def mutate_subdocument(
     ctx: Context,
     bucket_name: str,
@@ -286,10 +361,12 @@ def mutate_subdocument(
     array_add_unique_specs: list[dict[str, Any]] | None = None,
     counter_specs: list[dict[str, Any]] | None = None,
     create_parents: bool = False,
+    store_semantics: str | None = None,
 ) -> dict[str, Any]:
     """Modify parts of an EXISTING document without rewriting the whole thing, using
-    Couchbase sub-document mutation operations. The document must already exist — use
-    upsert_document_by_id first if it doesn't.
+    Couchbase sub-document mutation operations. By default the document must already
+    exist — either call upsert_document_by_id first, or pass store_semantics="UPSERT"
+    to have this call create it.
 
     Use this instead of upsert_document_by_id/replace_document_by_id when you only need to
     change, add, or remove a few fields — AND you already know the exact field path(s) to
@@ -324,6 +401,17 @@ def mutate_subdocument(
     create_parents: if True, missing intermediate path segments are created automatically
     for every category except replace_specs and remove_paths, which always require the full
     path to already exist.
+
+    store_semantics controls what happens when the DOCUMENT does not exist. Note the
+    distinction from create_parents: that one is about missing paths INSIDE a document,
+    this one is about the document itself.
+    - "REPLACE" (the default, and the previous behaviour): fail if the document is missing.
+    - "UPSERT": create the document if it is missing, then apply the mutations. This turns
+      the common "set this field, creating the record if needed" pattern into one call
+      instead of a get, a branch and a write.
+    - "INSERT": create the document, failing if it already exists.
+    With "UPSERT" or "INSERT" against a document that did not exist, replace_specs and
+    remove_paths have nothing to act on and will fail — use upsert_specs instead.
 
     At least one spec must be provided. As a rule of thumb, keep the combined number of
     specs across all categories to 16 or fewer — Couchbase limits subdocument operations
@@ -397,12 +485,12 @@ def mutate_subdocument(
         (
             "counter",
             counter_specs or [],
-            lambda s: subdoc.increment(
-                s["path"], s["delta"], create_parents=create_parents
-            )
-            if s["delta"] >= 0
-            else subdoc.decrement(
-                s["path"], abs(s["delta"]), create_parents=create_parents
+            lambda s: (
+                subdoc.increment(s["path"], s["delta"], create_parents=create_parents)
+                if s["delta"] >= 0
+                else subdoc.decrement(
+                    s["path"], abs(s["delta"]), create_parents=create_parents
+                )
             ),
         ),
     ]
@@ -425,13 +513,22 @@ def mutate_subdocument(
         logger.warning(f"Error performing sub-document mutation in {keyspace}: {error}")
         return {"error": error}
 
+    try:
+        options = _store_semantics_options(store_semantics)
+    except ValueError as e:
+        logger.warning(f"Invalid sub-document mutation for {keyspace}: {e}")
+        return {"error": str(e)}
+
     cluster = get_cluster_connection(ctx)
     bucket = connect_to_bucket(cluster, bucket_name)
 
     try:
         logger.debug(f"Performing sub-document mutation in {keyspace}")
         collection = bucket.scope(scope_name).collection(collection_name)
-        result = collection.mutate_in(document_id, specs)
+        if options is None:
+            result = collection.mutate_in(document_id, specs)
+        else:
+            result = collection.mutate_in(document_id, specs, options)
     except Exception as e:
         error_context = getattr(e, "error_context", None)
         failed_index = getattr(error_context, "first_error_index", None)
@@ -444,36 +541,6 @@ def mutate_subdocument(
         )
         return {"error": f"{e}{detail}"}
 
-    response: dict[str, Any] = {}
-    for index, (op, path) in enumerate(spec_meta):
-        bucket_for_op = response.setdefault(op, {})
-        if op == "counter":
-            # The installed SDK constructs MutateInResult without a transcoder
-            # (unlike LookupInResult), which makes content_as always raise for
-            # mutate_in results — fall back to decoding the raw field value.
-            new_value = None
-            for read_new_value in (
-                lambda index=index: result.content_as[int](index),
-                lambda index=index: int(
-                    json.loads(result._orig.raw_result["fields"][index]["value"])
-                ),
-            ):
-                try:
-                    new_value = read_new_value()
-                    break
-                except Exception:  # noqa: S112 (expected fallback attempt, not a swallowed bug)
-                    continue
-
-            if new_value is None:
-                logger.warning(
-                    f"Counter mutation at '{path}' in {keyspace} committed but "
-                    "its new value could not be read from the SDK result."
-                )
-                bucket_for_op[path] = {"success": True}
-                continue
-            bucket_for_op[path] = {"success": True, "value": new_value}
-            continue
-        bucket_for_op[path] = {"success": True}
-
+    response = _mutate_in_response(result, spec_meta, keyspace)
     logger.info(f"Successfully performed sub-document mutation in {keyspace}")
     return response

--- a/tests/integration/test_subdoc_store_semantics.py
+++ b/tests/integration/test_subdoc_store_semantics.py
@@ -1,0 +1,185 @@
+"""
+Integration tests for store_semantics on mutate_subdocument.
+
+The behaviour only a live server can show is the difference the parameter
+makes: the same call that fails against a missing document under the default
+semantics must succeed, and create the document, under "UPSERT".
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from conftest import (
+    create_mcp_session,
+    extract_payload,
+    get_test_collection,
+    get_test_scope,
+    require_test_bucket,
+)
+
+
+def _keyspace() -> dict[str, str]:
+    return {
+        "bucket_name": require_test_bucket(),
+        "scope_name": get_test_scope(),
+        "collection_name": get_test_collection(),
+    }
+
+
+async def _delete(session, doc_id: str) -> None:
+    await session.call_tool(
+        "delete_document_by_id",
+        arguments={**_keyspace(), "document_id": doc_id},
+    )
+
+
+async def _read(session, doc_id: str) -> dict:
+    response = await session.call_tool(
+        "get_document_by_id",
+        arguments={**_keyspace(), "document_id": doc_id},
+    )
+    return extract_payload(response)
+
+
+@pytest.mark.asyncio
+async def test_default_semantics_still_fail_on_a_missing_document() -> None:
+    """The previous behaviour must be unchanged when the parameter is omitted."""
+    doc_id = f"test_sem_{uuid.uuid4().hex[:8]}"
+
+    async with create_mcp_session() as session:
+        response = await session.call_tool(
+            "mutate_subdocument",
+            arguments={
+                **_keyspace(),
+                "document_id": doc_id,
+                "upsert_specs": [{"path": "created", "value": True}],
+            },
+        )
+        assert "error" in extract_payload(response)
+
+
+@pytest.mark.asyncio
+async def test_upsert_semantics_creates_the_missing_document() -> None:
+    doc_id = f"test_sem_{uuid.uuid4().hex[:8]}"
+
+    async with create_mcp_session() as session:
+        response = await session.call_tool(
+            "mutate_subdocument",
+            arguments={
+                **_keyspace(),
+                "document_id": doc_id,
+                "upsert_specs": [{"path": "created", "value": True}],
+                "store_semantics": "UPSERT",
+            },
+        )
+        payload = extract_payload(response)
+        try:
+            assert payload["upsert"]["created"] == {"success": True}, payload
+            assert await _read(session, doc_id) == {"created": True}
+        finally:
+            await _delete(session, doc_id)
+
+
+@pytest.mark.asyncio
+async def test_upsert_semantics_also_works_on_an_existing_document() -> None:
+    doc_id = f"test_sem_{uuid.uuid4().hex[:8]}"
+
+    async with create_mcp_session() as session:
+        await session.call_tool(
+            "upsert_document_by_id",
+            arguments={
+                **_keyspace(),
+                "document_id": doc_id,
+                "document_content": {"existing": True},
+            },
+        )
+        try:
+            response = await session.call_tool(
+                "mutate_subdocument",
+                arguments={
+                    **_keyspace(),
+                    "document_id": doc_id,
+                    "upsert_specs": [{"path": "added", "value": 1}],
+                    "store_semantics": "UPSERT",
+                },
+            )
+            assert extract_payload(response)["upsert"]["added"] == {"success": True}
+            assert await _read(session, doc_id) == {"existing": True, "added": 1}
+        finally:
+            await _delete(session, doc_id)
+
+
+@pytest.mark.asyncio
+async def test_insert_semantics_fails_when_the_document_exists() -> None:
+    doc_id = f"test_sem_{uuid.uuid4().hex[:8]}"
+
+    async with create_mcp_session() as session:
+        await session.call_tool(
+            "upsert_document_by_id",
+            arguments={
+                **_keyspace(),
+                "document_id": doc_id,
+                "document_content": {"existing": True},
+            },
+        )
+        try:
+            response = await session.call_tool(
+                "mutate_subdocument",
+                arguments={
+                    **_keyspace(),
+                    "document_id": doc_id,
+                    "upsert_specs": [{"path": "added", "value": 1}],
+                    "store_semantics": "INSERT",
+                },
+            )
+            assert "error" in extract_payload(response)
+            assert await _read(session, doc_id) == {"existing": True}
+        finally:
+            await _delete(session, doc_id)
+
+
+@pytest.mark.asyncio
+async def test_insert_semantics_creates_a_missing_document() -> None:
+    doc_id = f"test_sem_{uuid.uuid4().hex[:8]}"
+
+    async with create_mcp_session() as session:
+        response = await session.call_tool(
+            "mutate_subdocument",
+            arguments={
+                **_keyspace(),
+                "document_id": doc_id,
+                "upsert_specs": [{"path": "created", "value": True}],
+                "store_semantics": "INSERT",
+            },
+        )
+        try:
+            assert extract_payload(response)["upsert"]["created"] == {"success": True}
+            assert await _read(session, doc_id) == {"created": True}
+        finally:
+            await _delete(session, doc_id)
+
+
+@pytest.mark.asyncio
+async def test_unknown_semantics_is_rejected_and_nothing_is_created() -> None:
+    doc_id = f"test_sem_{uuid.uuid4().hex[:8]}"
+
+    async with create_mcp_session() as session:
+        response = await session.call_tool(
+            "mutate_subdocument",
+            arguments={
+                **_keyspace(),
+                "document_id": doc_id,
+                "upsert_specs": [{"path": "created", "value": True}],
+                "store_semantics": "CREATE_IF_MISSING",
+            },
+        )
+        payload = extract_payload(response)
+        assert "CREATE_IF_MISSING" in payload["error"]
+
+        check = await session.call_tool(
+            "get_document_by_id",
+            arguments={**_keyspace(), "document_id": doc_id},
+        )
+        assert check.isError, "a rejected mutation must not have created the document"

--- a/tests/unit/test_subdoc_store_semantics.py
+++ b/tests/unit/test_subdoc_store_semantics.py
@@ -1,0 +1,105 @@
+"""Unit tests for store_semantics on mutate_subdocument."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from couchbase.subdocument import StoreSemantics
+
+from cb_mcp.tools.kv import STORE_SEMANTICS, mutate_subdocument
+
+
+def _make_ctx_with_collection() -> tuple[SimpleNamespace, MagicMock, MagicMock]:
+    """Build a Context plus its underlying cluster + collection mock."""
+    cluster = MagicMock()
+    bucket = MagicMock()
+    collection = MagicMock()
+    bucket.scope.return_value.collection.return_value = collection
+    cluster.bucket.return_value = bucket
+
+    ctx = SimpleNamespace(
+        request_context=SimpleNamespace(
+            lifespan_context=SimpleNamespace(
+                cluster_provider=SimpleNamespace(get_cluster=lambda c: cluster),
+            )
+        )
+    )
+    return ctx, cluster, collection
+
+
+SPEC = [{"path": "a", "value": 1}]
+
+
+class TestStoreSemantics:
+    def test_omitting_it_preserves_the_previous_call_shape(self) -> None:
+        """The default must remain exactly what it was: no options object."""
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            mutate_subdocument(ctx, "b", "s", "c", "doc1", upsert_specs=SPEC)
+
+        assert len(collection.mutate_in.call_args.args) == 2
+
+    def test_every_documented_value_reaches_the_sdk(self) -> None:
+        for name, expected in STORE_SEMANTICS.items():
+            ctx, cluster, collection = _make_ctx_with_collection()
+
+            with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+                result = mutate_subdocument(
+                    ctx,
+                    "b",
+                    "s",
+                    "c",
+                    "doc1",
+                    upsert_specs=SPEC,
+                    store_semantics=name,
+                )
+
+            assert "error" not in result, name
+            options = dict(collection.mutate_in.call_args.args[2])
+            assert options["store_semantics"] is expected, name
+
+    def test_documented_values_match_the_docstring(self) -> None:
+        """Guard against the mapping and the docstring drifting apart."""
+        for name in STORE_SEMANTICS:
+            assert f'"{name}"' in mutate_subdocument.__doc__, name
+
+    def test_upsert_semantics_is_the_document_creating_one(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            mutate_subdocument(
+                ctx, "b", "s", "c", "doc1", upsert_specs=SPEC, store_semantics="UPSERT"
+            )
+
+        options = dict(collection.mutate_in.call_args.args[2])
+        assert options["store_semantics"] is StoreSemantics.UPSERT
+
+    def test_unknown_value_is_rejected_before_mutating(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            result = mutate_subdocument(
+                ctx,
+                "b",
+                "s",
+                "c",
+                "doc1",
+                upsert_specs=SPEC,
+                store_semantics="CREATE_IF_MISSING",
+            )
+
+        assert "CREATE_IF_MISSING" in result["error"]
+        collection.mutate_in.assert_not_called()
+
+    def test_missing_specs_are_reported_before_store_semantics(self) -> None:
+        """A caller making both mistakes is told about the one that makes the
+        call meaningless, rather than about an option it would never use."""
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            result = mutate_subdocument(ctx, "b", "s", "c", "doc1", store_semantics="X")
+
+        assert "At least one mutation spec" in result["error"]
+        collection.mutate_in.assert_not_called()


### PR DESCRIPTION
## Related Issue

Resolves: https://github.com/couchbase/mcp-server-couchbase/issues/270

## What does this change do?

Adds an optional `store_semantics` parameter to `mutate_subdocument`. It accepts
`REPLACE`, which is the default and the existing behaviour, `UPSERT`, which
creates the document if it is missing and then applies the mutations, and
`INSERT`, which creates it and fails if it already exists.

An unknown value is rejected before the mutation is attempted.

## Why is this change needed?

`mutate_subdocument` failed outright when the document did not exist. The common
pattern of "set this field, creating the record if needed" therefore took three
tool calls: a get, a branch, and either an upsert or a mutate. It also carried a
race between the read and the write. The SDK does this in one operation.

The docstring is explicit about the distinction from `create_parents`, which is
the neighbouring parameter most likely to be confused with it. `create_parents`
concerns missing paths inside a document. `store_semantics` concerns the
document itself. The docstring also states that `replace_specs` and
`remove_paths` have nothing to act on when the document is being created, so
those combinations fail.

## Evidence of Testing

Tested at commit `671b49cc9b06fbe545379b51d49ef2ee5a9e9f79`.

**Static checks:**

```
uv run ruff check src/            →  All checks passed
```

**Unit tests:**

```
uv run pytest tests/unit -q       →  513 passed
```

New unit tests in `tests/unit/test_subdoc_store_semantics.py`, including one
asserting that every value in the mapping appears in the docstring, so the two
cannot drift apart.

**Integration tests, self-managed Couchbase Server Enterprise 8.0.1, two-node
Docker cluster with one replica:**

```
uv run pytest tests/integration/test_subdoc_store_semantics.py \
              tests/integration/test_kv_tools.py \
              tests/integration/test_read_only.py -v    →  41 passed
```

**Integration tests, Couchbase Capella 8.0.2 (AWS us-east-1), travel-sample:**

```
uv run pytest tests/integration/test_subdoc_store_semantics.py \
              tests/integration/test_read_only.py -v    →  11 passed
```

**Full suite, against a baseline on unmodified `main`:**

```
main @ 660ade3, untouched   ->  3 failed, 123 passed, 12 skipped   (138 collected)
this branch @ 671b49c      ->  3 failed, 129 passed, 12 skipped   (144 collected)
```

The same three failures, the same twelve skips, and the pass count up by exactly
the six tests this branch adds. Both runs are on the same two-node cluster,
minutes apart.

The three failures are `test_fts_tools.py::test_run_fts_query_*`. On this local
cluster the seeded Search index never becomes queryable inside the fixture's
300-second timeout, reporting `query succeeded but returned no rows for the
seeded marker`. They fail before this change and after it, and nothing here
touches Search.

The twelve skips are upstream's own tests declining to assert against an empty
cluster: nine in `test_index_tools.py` because this cluster carries no GSI
indexes, and three in `test_performance_tools.py` because
`system:completed_requests` holds no query of the shape they need. The tests
this PR adds skip nothing, in either environment.

One note for anyone reproducing this. A local cluster whose GSI indexer storage
mode was never set will also fail the three `test_index_tools.py` create and
drop tests with `Please Set Indexer Storage Mode Before Create Index`. That is
the cluster, not this change; `POST /settings/indexes` with `storageMode=plasma`
clears it. It cost us a baseline run, so it is written down here.

Both transcripts and their `--junitxml` output are available on request.

The central pair in `tests/integration/test_subdoc_store_semantics.py` is the
same call against a missing document. It fails under the default semantics.
Under `UPSERT` it succeeds and the document is created. That difference is the
feature.

**Environments tested** (both required):

- [x] Couchbase Capella (version: 8.0.2, AWS us-east-1)
- [x] Self-managed Couchbase Server (version: Enterprise 8.0.1, two-node Docker)

**Manual verification:**

Exercised through a scripted MCP client over stdio, built on the official `mcp`
Python SDK, against the two-node self-managed cluster. The same mutation is run
twice against a document ID that does not exist, differing only in
`store_semantics`:

```
CALL  mutate_subdocument  (default semantics, missing document)
      response : {"error":"DocumentNotFoundException(<ec=101,
                  category=couchbase.key_value, ...
                  'key': 'manual_check_missing_5f08cbbe', ...>)"}

CALL  mutate_subdocument  (store_semantics=UPSERT)
      response : {"upsert":{"created_by":{"success":true}}}

CALL  get_document_by_id  (the document now exists)
      response : {"created_by":"manual check"}
```

The first response is what the tool does today and still does when the parameter
is omitted, which is the part a reviewer most needs to see is unchanged.

**Read-only mode:** no new tools and no reclassification.
`tests/integration/test_read_only.py` passed in both environments as part of the
runs above.

## Compatibility Considerations

- **Managed MCP:** no change. Nothing touches `cb_mcp.core`.
- **Tool interfaces:** one optional parameter, defaulted to the previous
  behaviour. With it omitted the SDK is called with the same signature as
  before, covered by a test.
- **Return shapes:** unchanged.
- **Annotations:** `TOOL_ANNOTATIONS` was reviewed and left as it was. The tool
  can now create a document, but `destructiveHint` already covers the write and
  the operation stays non-idempotent under `INSERT`, so the existing hints
  remain accurate. Flagging it explicitly because this changes what the tool can
  do to cluster state. Say so if you read it differently.
- **Confirmation:** the elicitation prompt is built from the keyspace and
  document ID, so a user confirming this tool is not shown that `UPSERT`
  semantics may create a document that does not exist. Out of scope here, but
  worth a follow-up if you agree.
- **Capella vs self-managed:** identical behaviour, confirmed by running the
  same tests against both.
- **Dependencies:** none added.
- **`_mutate_in_response`:** extracted from `mutate_subdocument` with its
  behaviour unchanged. Adding the parameter pushed that function past this
  project's configured branch and statement limits, and lifting the block out is
  what brings it back under them.

## Note on the other PRs against this issue

Issue #270 covers four independent changes. Each stands alone. All four touch
`src/cb_mcp/tools/kv.py` and the KV table in the docs, so whichever merges
second needs a rebase. That is a textual overlap and not a dependency.

## Checklist

- [x] Linked to an issue
- [x] Uses the Couchbase SDK (no REST)
- [x] Works on both Capella and self-managed Couchbase Server
- [x] No changes to `cb_mcp.core` contracts / managed MCP interfaces
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Read-only mode and tool annotations handled, reviewed as described above
- [x] Evidence of testing included above
- [x] Docs updated (README, DOCKER.md)
- [x] Lint and pre-commit pass
