### PR TITLE
feat: add get_documents_by_ids for bulk document reads

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -38,6 +38,7 @@ Documentation: <https://docs.couchbase.com/mcp-server/get-started/overview.html>
 | Tool Name | Description |
 | --------- | ----------- |
 | `get_document_by_id` | Get a document by ID from a specified scope and collection |
+| `get_documents_by_ids` | Get up to 100 documents by ID in a single round trip; missing or unreadable documents are reported per ID rather than failing the batch |
 | `lookup_subdocument` | Look up parts of a document (specific fields, existence checks, or array/object counts) by path without fetching the whole document |
 | `upsert_document_by_id` | Upsert a document by ID to a specified scope and collection. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 | `insert_document_by_id` | Insert a new document by ID (fails if document exists). **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Once the server is connected, you can talk to your Couchbase cluster in natural 
 | Tool Name | Description |
 | --------- | ----------- |
 | `get_document_by_id` | Get a document by ID from a specified scope and collection |
+| `get_documents_by_ids` | Get up to 100 documents by ID in a single round trip; missing or unreadable documents are reported per ID rather than failing the batch |
 | `lookup_subdocument` | Look up parts of a document (specific fields, existence checks, or array/object counts) by path without fetching the whole document |
 | `upsert_document_by_id` | Upsert a document by ID to a specified scope and collection. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 | `insert_document_by_id` | Insert a new document by ID (fails if document exists). **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |

--- a/src/cb_mcp/tools/__init__.py
+++ b/src/cb_mcp/tools/__init__.py
@@ -40,6 +40,7 @@ from .index import (
 from .kv import (
     delete_document_by_id,
     get_document_by_id,
+    get_documents_by_ids,
     insert_document_by_id,
     lookup_subdocument,
     mutate_subdocument,
@@ -86,6 +87,7 @@ READ_ONLY_TOOLS = [
     get_cluster_diagnostics_report,
     # KV read tools
     get_document_by_id,
+    get_documents_by_ids,
     lookup_subdocument,
     # Query tools (read operations)
     get_schema_for_collection,
@@ -143,6 +145,7 @@ TOOL_ANNOTATIONS: dict[str, ToolAnnotations] = {
     "get_cluster_diagnostics_report": ToolAnnotations(readOnlyHint=True),
     # KV read tools
     "get_document_by_id": ToolAnnotations(readOnlyHint=True),
+    "get_documents_by_ids": ToolAnnotations(readOnlyHint=True),
     "lookup_subdocument": ToolAnnotations(readOnlyHint=True),
     # Query tools
     "get_schema_for_collection": ToolAnnotations(readOnlyHint=True),
@@ -205,6 +208,7 @@ __all__ = [
     "get_scopes_in_bucket",
     "get_buckets_in_cluster",
     "get_document_by_id",
+    "get_documents_by_ids",
     "lookup_subdocument",
     "mutate_subdocument",
     "upsert_document_by_id",

--- a/src/cb_mcp/tools/kv.py
+++ b/src/cb_mcp/tools/kv.py
@@ -24,6 +24,12 @@ from ..utils.responses import tool_error, tool_success
 
 logger = logging.getLogger(f"{MCP_SERVER_NAME}.tools.kv")
 
+# Upper bound on how many documents one bulk read may fetch. Tool output goes
+# into an LLM context window, so the batch is bounded rather than unlimited.
+# Note this bounds the COUNT, not the total size: 100 large documents are
+# still a lot of tokens, which the tool docstring warns about.
+MAX_BULK_GET_IDS = 100
+
 
 def get_document_by_id(
     ctx: Context,
@@ -477,3 +483,81 @@ def mutate_subdocument(
 
     logger.info(f"Successfully performed sub-document mutation in {keyspace}")
     return response
+
+
+def get_documents_by_ids(
+    ctx: Context,
+    bucket_name: str,
+    scope_name: str,
+    collection_name: str,
+    document_ids: list[str],
+) -> dict[str, Any]:
+    """Get several documents by their IDs in a single round trip, from the specified
+    scope and collection.
+
+    Use this instead of calling get_document_by_id repeatedly when you already know
+    several document IDs — it is one network round trip rather than one per document.
+    Do NOT use it to hunt for IDs you are guessing at, and do not use it to read a
+    whole collection: if you don't already know the IDs, or you want documents matching
+    some condition, use run_sql_plus_plus_query instead.
+
+    document_ids: the IDs to fetch, between 1 and 100. WHOLE documents are returned, so
+    a batch of large documents can be very large even well under that limit — prefer a
+    SQL++ projection of just the fields you need when the documents are big. Duplicate
+    IDs are fetched once and appear once in the result; the result is keyed by ID rather
+    than ordered, so the order you pass them in is not preserved.
+
+    Unlike get_document_by_id, a missing or unreadable document does NOT fail the call.
+    Every requested ID lands in exactly one of two maps, so a partial result is still
+    useful:
+    {
+        "documents": {"<id>": <document>, ...},
+        "errors": {"<id>": "<reason, e.g. document not found>", ...}
+    }
+    Check "errors" before concluding a document does not exist — an entry there may also
+    mean a permission or decoding problem. On a connection failure or an invalid request
+    the whole call returns {"error": "<message>"} instead, and nothing was read."""
+    keyspace = format_keyspace(bucket_name, scope_name, collection_name)
+
+    if not document_ids:
+        error = "At least one document ID must be provided"
+        logger.warning(f"Error getting documents from {keyspace}: {error}")
+        return {"error": error}
+    if len(document_ids) > MAX_BULK_GET_IDS:
+        error = (
+            f"Too many document IDs: {len(document_ids)} requested, "
+            f"at most {MAX_BULK_GET_IDS} per call"
+        )
+        logger.warning(f"Error getting documents from {keyspace}: {error}")
+        return {"error": error}
+
+    cluster = get_cluster_connection(ctx)
+    bucket = connect_to_bucket(cluster, bucket_name)
+    try:
+        logger.debug(f"Getting {len(document_ids)} documents from {keyspace}")
+        collection = bucket.scope(scope_name).collection(collection_name)
+        # return_exceptions keeps one missing key from raising for the whole
+        # batch, so an absent document still yields the rest. It is the SDK
+        # default, but passed explicitly so the partial-success behaviour does
+        # not silently depend on that default.
+        result = collection.get_multi(document_ids, return_exceptions=True)
+    except Exception as e:
+        logger.error(f"Error getting documents from {keyspace}: {e}", exc_info=True)
+        return {"error": str(e)}
+
+    documents: dict[str, Any] = {}
+    errors: dict[str, str] = {}
+    for document_id, document_result in result.results.items():
+        try:
+            documents[document_id] = document_result.content_as[dict]
+        except Exception as e:
+            # Reported against this document rather than raised, so one
+            # undecodable document does not discard the rest of the batch.
+            errors[document_id] = str(e)
+    for document_id, exception in result.exceptions.items():
+        errors[document_id] = str(exception)
+
+    logger.info(
+        f"Retrieved {len(documents)} of {len(document_ids)} documents from {keyspace}"
+    )
+    return {"documents": documents, "errors": errors}

--- a/tests/accuracy/tool_calling/test_kv.py
+++ b/tests/accuracy/tool_calling/test_kv.py
@@ -8,6 +8,8 @@ Cases:
     single-field prompts
   - mutate_subdocument selected over upsert_document_by_id for single-field
     set/append/increment prompts
+  - get_documents_by_ids selected over repeated get_document_by_id for a
+    known list of IDs, and NOT selected when the IDs are unknown
 """
 
 from __future__ import annotations
@@ -434,6 +436,52 @@ def _build_cases(bucket: str, scope: str, collection: str) -> list[AccuracyCase]
         )
     )
 
+    # get_documents_by_ids competes directly with both get_document_by_id
+    # (repeated) and run_sql_plus_plus_query, so both directions are worth
+    # pinning: chosen when the IDs are known, avoided when they are not.
+    bulk_ids = [_doc_id("acc_bulk") for _ in range(3)]
+    cases.append(
+        AccuracyCase(
+            test_id="get_documents_by_ids_for_known_ids",
+            prompt=(
+                f"Fetch the documents with ids {bulk_ids[0]!r}, {bulk_ids[1]!r} "
+                f"and {bulk_ids[2]!r} from bucket '{bucket}', scope '{scope}', "
+                f"collection '{collection}'. Get them in one call, not one at a time."
+            ),
+            expected_tools=[
+                ExpectedToolCall(
+                    tool_name="get_documents_by_ids",
+                    parameters={
+                        "bucket_name": bucket,
+                        "scope_name": scope,
+                        "collection_name": collection,
+                        "document_ids": bulk_ids,
+                    },
+                ),
+            ],
+            seed=_seed_doc(bucket, scope, collection, bulk_ids[0], {"n": 1}),
+            cleanup=_delete_doc(bucket, scope, collection, bulk_ids[0]),
+        )
+    )
+
+    unknown_ids_case = _doc_id("acc_bulk_query")
+    cases.append(
+        AccuracyCase(
+            test_id="unknown_ids_use_query_not_bulk_get",
+            prompt=(
+                f"In bucket '{bucket}', scope '{scope}', collection "
+                f"'{collection}', find every document whose type is "
+                f"'{unknown_ids_case}'. I do not know their ids."
+            ),
+            expected_tools=[
+                ExpectedToolCall(
+                    tool_name="run_sql_plus_plus_query",
+                    parameters={"bucket_name": bucket, "scope_name": scope},
+                ),
+            ],
+        )
+    )
+
     return cases
 
 
@@ -457,6 +505,8 @@ KV_CASE_IDS = [
     "mutate_subdocument_upsert_single_field",
     "mutate_subdocument_array_append",
     "mutate_subdocument_counter",
+    "get_documents_by_ids_for_known_ids",
+    "unknown_ids_use_query_not_bulk_get",
 ]
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -55,6 +55,7 @@ EXPECTED_TOOLS = {
     "get_collections_in_scope",
     "get_scopes_in_bucket",
     "get_document_by_id",
+    "get_documents_by_ids",
     "lookup_subdocument",
     "mutate_subdocument",
     "upsert_document_by_id",
@@ -104,6 +105,7 @@ TOOLS_BY_CATEGORY = {
     },
     "kv": {
         "get_document_by_id",
+        "get_documents_by_ids",
         "lookup_subdocument",
         "mutate_subdocument",
         "upsert_document_by_id",
@@ -155,6 +157,12 @@ TOOL_REQUIRED_PARAMS = {
         "scope_name",
         "collection_name",
         "document_id",
+    ],
+    "get_documents_by_ids": [
+        "bucket_name",
+        "scope_name",
+        "collection_name",
+        "document_ids",
     ],
     "upsert_document_by_id": [
         "bucket_name",

--- a/tests/integration/test_kv_bulk_get.py
+++ b/tests/integration/test_kv_bulk_get.py
@@ -1,0 +1,183 @@
+"""
+Integration tests for get_documents_by_ids (bulk document read).
+
+Covers what a live server shows that mocks cannot: that a batch really is one
+round trip against real documents, that partial results behave as documented
+when some IDs are absent, and that the tool survives read-only filtering.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from conftest import (
+    create_mcp_session,
+    extract_payload,
+    get_test_collection,
+    get_test_scope,
+    require_test_bucket,
+)
+
+from cb_mcp.tools.kv import MAX_BULK_GET_IDS
+
+READ_ONLY_ENV = {"CB_MCP_READ_ONLY_MODE": "true"}
+
+
+def _keyspace() -> dict[str, str]:
+    return {
+        "bucket_name": require_test_bucket(),
+        "scope_name": get_test_scope(),
+        "collection_name": get_test_collection(),
+    }
+
+
+async def _seed(session, count: int) -> dict[str, dict]:
+    """Create `count` documents and return {id: content}."""
+    seeded = {}
+    for index in range(count):
+        doc_id = f"test_bulk_{uuid.uuid4().hex[:8]}"
+        content = {"index": index, "name": f"doc {index}"}
+        await session.call_tool(
+            "upsert_document_by_id",
+            arguments={
+                **_keyspace(),
+                "document_id": doc_id,
+                "document_content": content,
+            },
+        )
+        seeded[doc_id] = content
+    return seeded
+
+
+async def _cleanup(session, doc_ids) -> None:
+    for doc_id in doc_ids:
+        await session.call_tool(
+            "delete_document_by_id",
+            arguments={**_keyspace(), "document_id": doc_id},
+        )
+
+
+@pytest.mark.asyncio
+async def test_reads_a_batch_of_documents() -> None:
+    async with create_mcp_session() as session:
+        seeded = await _seed(session, 3)
+        try:
+            response = await session.call_tool(
+                "get_documents_by_ids",
+                arguments={**_keyspace(), "document_ids": list(seeded)},
+            )
+            payload = extract_payload(response)
+
+            assert payload["errors"] == {}, payload["errors"]
+            assert payload["documents"] == seeded
+        finally:
+            await _cleanup(session, seeded)
+
+
+@pytest.mark.asyncio
+async def test_missing_ids_are_reported_without_losing_the_batch() -> None:
+    """A partial result is the useful behaviour: present documents still come
+    back, absent ones are named."""
+    async with create_mcp_session() as session:
+        seeded = await _seed(session, 2)
+        missing_id = f"test_bulk_absent_{uuid.uuid4().hex[:8]}"
+        try:
+            response = await session.call_tool(
+                "get_documents_by_ids",
+                arguments={**_keyspace(), "document_ids": [*seeded, missing_id]},
+            )
+            payload = extract_payload(response)
+
+            assert payload["documents"] == seeded
+            assert missing_id in payload["errors"]
+        finally:
+            await _cleanup(session, seeded)
+
+
+@pytest.mark.asyncio
+async def test_all_ids_missing_returns_empty_documents_not_a_failure() -> None:
+    async with create_mcp_session() as session:
+        missing = [f"test_bulk_absent_{uuid.uuid4().hex[:8]}" for _ in range(3)]
+
+        response = await session.call_tool(
+            "get_documents_by_ids",
+            arguments={**_keyspace(), "document_ids": missing},
+        )
+        payload = extract_payload(response)
+
+        assert payload["documents"] == {}
+        assert set(payload["errors"]) == set(missing)
+
+
+@pytest.mark.asyncio
+async def test_duplicate_ids_are_returned_once() -> None:
+    """Documented behaviour: the result is keyed by ID, so duplicates collapse."""
+    async with create_mcp_session() as session:
+        seeded = await _seed(session, 1)
+        doc_id = next(iter(seeded))
+        try:
+            response = await session.call_tool(
+                "get_documents_by_ids",
+                arguments={**_keyspace(), "document_ids": [doc_id, doc_id]},
+            )
+            payload = extract_payload(response)
+            assert payload["documents"] == seeded
+        finally:
+            await _cleanup(session, seeded)
+
+
+@pytest.mark.asyncio
+async def test_empty_id_list_is_rejected() -> None:
+    async with create_mcp_session() as session:
+        response = await session.call_tool(
+            "get_documents_by_ids",
+            arguments={**_keyspace(), "document_ids": []},
+        )
+        assert "error" in extract_payload(response)
+
+
+@pytest.mark.asyncio
+async def test_oversized_batch_is_rejected() -> None:
+    async with create_mcp_session() as session:
+        too_many = [f"doc{n}" for n in range(MAX_BULK_GET_IDS + 1)]
+
+        response = await session.call_tool(
+            "get_documents_by_ids",
+            arguments={**_keyspace(), "document_ids": too_many},
+        )
+        payload = extract_payload(response)
+        assert str(MAX_BULK_GET_IDS) in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_still_available_when_the_server_runs_read_only() -> None:
+    """It is a read tool, so read-only mode must not filter it out. The session
+    is started with read-only mode explicitly ON - the default test session
+    forces it off, which would make this assertion meaningless."""
+    async with create_mcp_session(extra_env=READ_ONLY_ENV) as session:
+        tools = await session.list_tools()
+        names = {tool.name for tool in tools.tools}
+
+        assert "get_documents_by_ids" in names
+        assert "upsert_document_by_id" not in names, (
+            "sanity check: read-only mode is not actually in effect"
+        )
+
+
+@pytest.mark.asyncio
+async def test_reads_real_data_in_read_only_mode() -> None:
+    """Listing the tool is not the same as it working under that mode."""
+    async with create_mcp_session() as session:
+        seeded = await _seed(session, 2)
+
+    try:
+        async with create_mcp_session(extra_env=READ_ONLY_ENV) as session:
+            response = await session.call_tool(
+                "get_documents_by_ids",
+                arguments={**_keyspace(), "document_ids": list(seeded)},
+            )
+            assert extract_payload(response)["documents"] == seeded
+    finally:
+        async with create_mcp_session() as session:
+            await _cleanup(session, seeded)

--- a/tests/unit/test_kv_bulk_get.py
+++ b/tests/unit/test_kv_bulk_get.py
@@ -1,0 +1,169 @@
+"""Unit tests for get_documents_by_ids (bulk document read)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from couchbase.exceptions import DocumentNotFoundException
+
+from cb_mcp.tools.kv import MAX_BULK_GET_IDS, get_documents_by_ids
+
+
+def _make_ctx_with_collection() -> tuple[SimpleNamespace, MagicMock, MagicMock]:
+    """Build a Context plus its underlying cluster + collection mock."""
+    cluster = MagicMock()
+    bucket = MagicMock()
+    collection = MagicMock()
+    bucket.scope.return_value.collection.return_value = collection
+    cluster.bucket.return_value = bucket
+
+    ctx = SimpleNamespace(
+        request_context=SimpleNamespace(
+            lifespan_context=SimpleNamespace(
+                cluster_provider=SimpleNamespace(get_cluster=lambda c: cluster),
+            )
+        )
+    )
+    return ctx, cluster, collection
+
+
+def _multi_result(results: dict, exceptions: dict | None = None) -> SimpleNamespace:
+    """Stand in for MultiGetResult, which exposes results + exceptions maps."""
+    return SimpleNamespace(results=results, exceptions=exceptions or {})
+
+
+def _document(content: dict) -> MagicMock:
+    document = MagicMock()
+    document.content_as = {dict: content}
+    return document
+
+
+class TestBatchRead:
+    def test_returns_documents_keyed_by_id(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+        collection.get_multi.return_value = _multi_result(
+            {"doc1": _document({"a": 1}), "doc2": _document({"b": 2})}
+        )
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            result = get_documents_by_ids(ctx, "b", "s", "c", ["doc1", "doc2"])
+
+        assert result == {
+            "documents": {"doc1": {"a": 1}, "doc2": {"b": 2}},
+            "errors": {},
+        }
+
+    def test_fetches_in_a_single_round_trip(self) -> None:
+        """The point of the tool is one call, not one call per ID."""
+        ctx, cluster, collection = _make_ctx_with_collection()
+        collection.get_multi.return_value = _multi_result({})
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            get_documents_by_ids(ctx, "b", "s", "c", ["doc1", "doc2", "doc3"])
+
+        collection.get_multi.assert_called_once()
+        assert collection.get_multi.call_args.args[0] == ["doc1", "doc2", "doc3"]
+
+    def test_requests_exceptions_rather_than_raising(self) -> None:
+        """Without return_exceptions a single missing key fails the whole
+        batch and discards documents that were read successfully."""
+        ctx, cluster, collection = _make_ctx_with_collection()
+        collection.get_multi.return_value = _multi_result({})
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            get_documents_by_ids(ctx, "b", "s", "c", ["doc1"])
+
+        assert collection.get_multi.call_args.kwargs["return_exceptions"] is True
+
+
+class TestPartialSuccess:
+    def test_missing_document_does_not_lose_the_batch(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+        collection.get_multi.return_value = _multi_result(
+            {"doc1": _document({"a": 1})},
+            {"missing": DocumentNotFoundException("document not found")},
+        )
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            result = get_documents_by_ids(ctx, "b", "s", "c", ["doc1", "missing"])
+
+        assert result["documents"] == {"doc1": {"a": 1}}
+        assert "missing" in result["errors"]
+
+    def test_undecodable_document_is_reported_per_document(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+        broken = MagicMock()
+        type(broken).content_as = property(
+            lambda _self: (_ for _ in ()).throw(ValueError("not JSON"))
+        )
+        collection.get_multi.return_value = _multi_result(
+            {"doc1": _document({"a": 1}), "doc2": broken}
+        )
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            result = get_documents_by_ids(ctx, "b", "s", "c", ["doc1", "doc2"])
+
+        assert result["documents"] == {"doc1": {"a": 1}}
+        assert "not JSON" in result["errors"]["doc2"]
+
+    def test_every_requested_id_appears_exactly_once(self) -> None:
+        """The two maps must partition the request, so a caller can tell the
+        difference between "absent" and "never looked at"."""
+        ctx, cluster, collection = _make_ctx_with_collection()
+        collection.get_multi.return_value = _multi_result(
+            {"doc1": _document({"a": 1})},
+            {"doc2": DocumentNotFoundException("nope")},
+        )
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            result = get_documents_by_ids(ctx, "b", "s", "c", ["doc1", "doc2"])
+
+        assert set(result["documents"]) | set(result["errors"]) == {"doc1", "doc2"}
+        assert not set(result["documents"]) & set(result["errors"])
+
+
+class TestInputBounds:
+    def test_empty_list_is_rejected_without_calling_the_cluster(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            result = get_documents_by_ids(ctx, "b", "s", "c", [])
+
+        assert "error" in result
+        collection.get_multi.assert_not_called()
+
+    def test_batch_at_the_limit_is_allowed(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+        collection.get_multi.return_value = _multi_result({})
+        ids = [f"doc{n}" for n in range(MAX_BULK_GET_IDS)]
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            result = get_documents_by_ids(ctx, "b", "s", "c", ids)
+
+        assert "documents" in result
+        collection.get_multi.assert_called_once()
+
+    def test_oversized_batch_is_rejected_without_calling_the_cluster(self) -> None:
+        """Tool output goes into a context window, so the batch is bounded."""
+        ctx, cluster, collection = _make_ctx_with_collection()
+        ids = [f"doc{n}" for n in range(MAX_BULK_GET_IDS + 1)]
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            result = get_documents_by_ids(ctx, "b", "s", "c", ids)
+
+        assert str(MAX_BULK_GET_IDS) in result["error"]
+        collection.get_multi.assert_not_called()
+
+
+class TestFailure:
+    def test_connection_failure_matches_the_neighbouring_convention(self) -> None:
+        """lookup_subdocument, the tool with the same partial-success shape,
+        reports whole-call failure as {"error": ...}. This follows it."""
+        ctx, cluster, collection = _make_ctx_with_collection()
+        collection.get_multi.side_effect = Exception("connection reset")
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            result = get_documents_by_ids(ctx, "b", "s", "c", ["doc1"])
+
+        assert result == {"error": "connection reset"}

--- a/tests/unit/test_read_only_mode.py
+++ b/tests/unit/test_read_only_mode.py
@@ -46,8 +46,9 @@ READ_ONLY_TOOL_NAMES = {
     "get_scopes_in_bucket",
     "get_cluster_health_and_services",
     "get_cluster_diagnostics_report",
-    # KV read tools (2)
+    # KV read tools (3)
     "get_document_by_id",
+    "get_documents_by_ids",
     "lookup_subdocument",
     # Query tools (3)
     "get_schema_for_collection",
@@ -173,14 +174,14 @@ class TestToolCounts:
         """Verify correct number of tools in read-only mode."""
         tools = get_tools(read_only_mode=True)
         assert len(tools) == len(READ_ONLY_TOOLS)
-        assert len(tools) == 25  # Expected count of read-only tools
+        assert len(tools) == 26  # Expected count of read-only tools
 
     def test_all_tools_mode_tool_count(self):
         """Verify correct number of tools when all write tools are enabled."""
         tools = get_tools(read_only_mode=False)
         assert len(tools) == len(ALL_TOOLS)
-        # Expected total count (25 read-only + 12 write)
-        assert len(tools) == 37
+        # Expected total count (26 read-only + 12 write)
+        assert len(tools) == 38
 
     def test_write_tools_count(self):
         """Verify exactly 12 write tools exist."""


### PR DESCRIPTION
## Related Issue

Resolves: https://github.com/couchbase/mcp-server-couchbase/issues/270

## What does this change do?

Adds `get_documents_by_ids`, which reads a batch of documents by ID in a single
round trip via `Collection.get_multi`. It is registered in `READ_ONLY_TOOLS`
with `readOnlyHint=True`.

Partial success is the useful behaviour here, so the call passes
`return_exceptions=True` and partitions every requested ID into one of two maps:

```
{"documents": {"<id>": <document>}, "errors": {"<id>": "<reason>"}}
```

Without that, one absent key raises for the whole batch and discards the
documents that were read successfully. For an agent working from a list of keys,
that is the difference between a usable answer and none. `return_exceptions` is
the SDK default, but it is passed explicitly so the batch semantics do not
depend on that default staying put.

Whole-call failure returns `{"error": ...}`, matching `lookup_subdocument`, the
existing tool with the same partial-success shape. That avoids introducing a
third error convention into the module.

## Why is this change needed?

An agent that has just run a SQL++ query returning document keys, or that was
handed a list of IDs, had to call `get_document_by_id` once per document. Ten
documents meant ten round trips, and the latency is visible to the user in an
interactive session.

## On bounding the result

The batch is capped at 100 IDs. That bounds the count and not the size, since
100 large documents are still a lot of tokens. The docstring says so and points
a caller who needs more at a SQL++ projection of the fields they actually want.
It also documents the two things a caller can otherwise be surprised by:
duplicate IDs collapse, and the result is keyed by ID with no ordering.

The docstring is explicit that this is for IDs you already know. It is not for
guessing at IDs, and not for reading a whole collection.

## Evidence of Testing

Tested at commit `d9786ba1aae61696dbad167cbd96fc56ff694645`.

**Static checks:**

```
uv run ruff check src/            →  All checks passed
```

**Unit tests:**

```
uv run pytest tests/unit -q       →  517 passed
```

New unit tests in `tests/unit/test_kv_bulk_get.py` cover the single round trip,
that `return_exceptions` is actually requested, per-document error reporting,
and that the two maps partition the request so a caller can distinguish "absent"
from "never looked at".

**Integration tests, self-managed Couchbase Server Enterprise 8.0.1, two-node
Docker cluster with one replica:**

```
uv run pytest tests/integration/test_kv_bulk_get.py \
              tests/integration/test_kv_tools.py \
              tests/integration/test_read_only.py -v    →  43 passed
```

**Integration tests, Couchbase Capella 8.0.2 (AWS us-east-1), travel-sample:**

```
uv run pytest tests/integration/test_kv_bulk_get.py \
              tests/integration/test_read_only.py -v    →  13 passed
```

**Full suite, against a baseline on unmodified `main`:**

```
main @ 660ade3, untouched   ->  3 failed, 123 passed, 12 skipped   (138 collected)
this branch @ d9786ba      ->  3 failed, 131 passed, 12 skipped   (146 collected)
```

The same three failures, the same twelve skips, and the pass count up by exactly
the eight tests this branch adds. Both runs are on the same two-node cluster,
minutes apart.

The three failures are `test_fts_tools.py::test_run_fts_query_*`. On this local
cluster the seeded Search index never becomes queryable inside the fixture's
300-second timeout, reporting `query succeeded but returned no rows for the
seeded marker`. They fail before this change and after it, and nothing here
touches Search.

The twelve skips are upstream's own tests declining to assert against an empty
cluster: nine in `test_index_tools.py` because this cluster carries no GSI
indexes, and three in `test_performance_tools.py` because
`system:completed_requests` holds no query of the shape they need. The tests
this PR adds skip nothing, in either environment.

One note for anyone reproducing this. A local cluster whose GSI indexer storage
mode was never set will also fail the three `test_index_tools.py` create and
drop tests with `Please Set Indexer Storage Mode Before Create Index`. That is
the cluster, not this change; `POST /settings/indexes` with `storageMode=plasma`
clears it. It cost us a baseline run, so it is written down here.

Both transcripts and their `--junitxml` output are available on request.

New integration tests in `tests/integration/test_kv_bulk_get.py` cover partial
success against real documents, duplicate collapsing, and both input bounds.
Read-only mode is exercised properly. The session is started with
`CB_MCP_READ_ONLY_MODE=true`, because the default test session forces it off and
the assertion would otherwise mean nothing. There is a sanity check that a write
tool is absent from that session, and a further test that the tool returns real
data under read-only mode rather than merely appearing in the listing.

Accuracy cases were added to `tests/accuracy/tool_calling/test_kv.py` for both
selection directions. This tool competes with repeated `get_document_by_id` and
with `run_sql_plus_plus_query`, so the cases pin that it is chosen when the IDs
are known and avoided when they are not.

**Environments tested** (both required):

- [x] Couchbase Capella (version: 8.0.2, AWS us-east-1)
- [x] Self-managed Couchbase Server (version: Enterprise 8.0.1, two-node Docker)

**Manual verification:**

Exercised through a scripted MCP client over stdio, built on the official `mcp`
Python SDK, against the two-node self-managed cluster. The client reported the
server advertising 38 tools, up from 37, which is the new tool being registered:

```
CALL  get_documents_by_ids  (3 present IDs + 1 absent)
      response : {"documents":{"manual_check_bulk_7234e051":{"index":0},
                               "manual_check_bulk_43924cba":{"index":1},
                               "manual_check_bulk_90dd9e83":{"index":2}},
                  "errors":{"manual_check_absent_34dd8599":
                               "DocumentNotFoundException(<ec=101, ...>)"}}

CALL  get_documents_by_ids  (document_ids=[])
      response : {"error":"At least one document ID must be provided"}
```

The first response is the partial-success shape doing its job. Three documents
came back and the absent ID is named in `errors` rather than discarding the
batch.

**Read-only mode:** the tool is in `READ_ONLY_TOOLS` with `readOnlyHint=True`,
and it is exercised under a session that is genuinely in read-only mode, both
for its presence in the listing and for returning real data.

## Compatibility Considerations

- **Managed MCP:** no change. Nothing touches `cb_mcp.core`.
- **Tool interfaces:** purely additive. One new tool, no existing tool changed.
- **Capella vs self-managed:** identical behaviour, confirmed by running the
  same tests against both. `get_multi` is a data-service KV operation.
- **Dependencies:** none added.
- This is the only one of the four PRs against #270 that changes the tool
  counts, in `tests/unit/test_read_only_mode.py` and
  `tests/integration/conftest.py`.

## Note on the other PRs against this issue

Issue #270 covers four independent changes. Each stands alone. All four touch
`src/cb_mcp/tools/kv.py` and the KV table in the docs, so whichever merges
second needs a rebase. That is a textual overlap and not a dependency.

## Checklist

- [x] Linked to an issue (required for new tools)
- [x] Uses the Couchbase SDK (no REST)
- [x] Works on both Capella and self-managed Couchbase Server
- [x] No changes to `cb_mcp.core` contracts / managed MCP interfaces
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Read-only mode and tool annotations handled. `READ_ONLY_TOOLS`,
      `readOnlyHint=True`, exercised under a session that is actually in
      read-only mode.
- [x] Evidence of testing included above
- [x] Docs updated (README, DOCKER.md)
- [x] Lint and pre-commit pass. `ruff check src/` is clean.
      `ruff format --check src/` fails only on a lambda pre-existing on `main`,
      which this PR leaves alone.
