### PR TITLE
feat: add durability option to mutate_subdocument

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -43,7 +43,7 @@ Documentation: <https://docs.couchbase.com/mcp-server/get-started/overview.html>
 | `insert_document_by_id` | Insert a new document by ID (fails if document exists). **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 | `replace_document_by_id` | Replace an existing document by ID (fails if document doesn't exist). **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 | `delete_document_by_id` | Delete a document by ID from a specified scope and collection. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
-| `mutate_subdocument` | Modify parts of an existing document (upsert, insert, replace, remove, array ops, counters) by path without rewriting the whole document. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
+| `mutate_subdocument` | Modify parts of an existing document (upsert, insert, replace, remove, array ops, counters) by path without rewriting the whole document. Optional `durability`. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 
 ### Query and indexing tools
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Once the server is connected, you can talk to your Couchbase cluster in natural 
 | `insert_document_by_id` | Insert a new document by ID (fails if document exists). **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 | `replace_document_by_id` | Replace an existing document by ID (fails if document doesn't exist). **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 | `delete_document_by_id` | Delete a document by ID from a specified scope and collection. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
-| `mutate_subdocument` | Modify parts of an existing document (upsert, insert, replace, remove, array ops, counters) by path without rewriting the whole document. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
+| `mutate_subdocument` | Modify parts of an existing document (upsert, insert, replace, remove, array ops, counters) by path without rewriting the whole document. Optional `durability`. **Disabled by default when `CB_MCP_READ_ONLY_MODE=true`.** |
 
 ### Query and indexing tools
 

--- a/src/cb_mcp/tools/kv.py
+++ b/src/cb_mcp/tools/kv.py
@@ -14,7 +14,9 @@ import logging
 from typing import Any
 
 import couchbase.subdocument as subdoc
+from couchbase.durability import DurabilityLevel, ServerDurability
 from couchbase.exceptions import CouchbaseException
+from couchbase.options import MutateInOptions
 from fastmcp import Context
 
 from ..utils.connection import connect_to_bucket, format_keyspace
@@ -23,6 +25,48 @@ from ..utils.context import get_cluster_connection
 from ..utils.responses import tool_error, tool_success
 
 logger = logging.getLogger(f"{MCP_SERVER_NAME}.tools.kv")
+
+# Durability levels accepted by the sub-document mutation tool, mapped to the
+# SDK enum. Exposed as strings because MCP tool parameters are JSON-typed and
+# LLM-generated; the mapping doubles as input validation at the tool boundary.
+DURABILITY_LEVELS: dict[str, DurabilityLevel] = {
+    "NONE": DurabilityLevel.NONE,
+    "MAJORITY": DurabilityLevel.MAJORITY,
+    "MAJORITY_AND_PERSIST_TO_ACTIVE": DurabilityLevel.MAJORITY_AND_PERSIST_TO_ACTIVE,
+    "PERSIST_TO_MAJORITY": DurabilityLevel.PERSIST_TO_MAJORITY,
+}
+
+
+def _mutate_in_write_options(durability: str | None = None) -> MutateInOptions | None:
+    """Build MutateInOptions carrying durability, or None if unset.
+
+    Returning None when nothing is requested keeps the call path identical to
+    the one used before this parameter existed, so default behavior is
+    unchanged.
+
+    Raises ValueError for an unknown durability level so the calling tool can
+    report an actionable message rather than handing an invalid value to the
+    SDK.
+    """
+    kwargs: dict[str, Any] = {}
+
+    if durability is not None:
+        level = DURABILITY_LEVELS.get(durability)
+        if level is None:
+            raise ValueError(
+                f"durability must be one of {sorted(DURABILITY_LEVELS)}; "
+                f"got {durability!r}"
+            )
+        # The SDK reads the ``durability`` option key and derives the
+        # wire-level durability_level from it. ``durability_level`` is not a
+        # supported option key: the Options classes are unvalidated dict
+        # subclasses, so passing it is accepted and then silently dropped,
+        # which would turn the guarantee into a no-op.
+        kwargs["durability"] = ServerDurability(level=level)
+
+    if not kwargs:
+        return None
+    return MutateInOptions(**kwargs)
 
 
 def get_document_by_id(
@@ -270,6 +314,52 @@ def lookup_subdocument(
     return response
 
 
+def _mutate_in_response(
+    result: Any,
+    spec_meta: list[tuple[str, str]],
+    keyspace: str,
+) -> dict[str, Any]:
+    """Build the per-category path -> outcome mapping for a committed mutate_in.
+
+    Extracted from mutate_subdocument unchanged. Adding the durability
+    parameter pushed that function past the project's configured branch and
+    statement limits; lifting this block out is what brings it back under them.
+    """
+    response: dict[str, Any] = {}
+    for index, (op, path) in enumerate(spec_meta):
+        bucket_for_op = response.setdefault(op, {})
+        if op != "counter":
+            bucket_for_op[path] = {"success": True}
+            continue
+
+        # The installed SDK constructs MutateInResult without a transcoder
+        # (unlike LookupInResult), which makes content_as always raise for
+        # mutate_in results - fall back to decoding the raw field value.
+        new_value = None
+        for read_new_value in (
+            lambda index=index: result.content_as[int](index),
+            lambda index=index: int(
+                json.loads(result._orig.raw_result["fields"][index]["value"])
+            ),
+        ):
+            try:
+                new_value = read_new_value()
+                break
+            except Exception:  # noqa: S112 (expected fallback attempt, not a swallowed bug)
+                continue
+
+        if new_value is None:
+            logger.warning(
+                f"Counter mutation at '{path}' in {keyspace} committed but "
+                "its new value could not be read from the SDK result."
+            )
+            bucket_for_op[path] = {"success": True}
+            continue
+        bucket_for_op[path] = {"success": True, "value": new_value}
+
+    return response
+
+
 def mutate_subdocument(
     ctx: Context,
     bucket_name: str,
@@ -286,6 +376,7 @@ def mutate_subdocument(
     array_add_unique_specs: list[dict[str, Any]] | None = None,
     counter_specs: list[dict[str, Any]] | None = None,
     create_parents: bool = False,
+    durability: str | None = None,
 ) -> dict[str, Any]:
     """Modify parts of an EXISTING document without rewriting the whole thing, using
     Couchbase sub-document mutation operations. The document must already exist — use
@@ -324,6 +415,18 @@ def mutate_subdocument(
     create_parents: if True, missing intermediate path segments are created automatically
     for every category except replace_specs and remove_paths, which always require the full
     path to already exist.
+
+    durability: optional write-durability guarantee for the mutation, one of "NONE"
+    (default: acknowledged from the active node's memory), "MAJORITY" (replicated to a
+    majority of nodes), "MAJORITY_AND_PERSIST_TO_ACTIVE" (replicated to a majority and
+    written to disk on the active node) or "PERSIST_TO_MAJORITY" (written to disk on a
+    majority of nodes). Anything above "NONE" needs enough replicas to satisfy it; if the
+    cluster cannot, the call fails rather than quietly downgrading. An unrecognised value
+    is rejected before the mutation is attempted.
+
+    Note that mutate_in has no expiry option of its own. MutateInOptions accepts cas,
+    durability, store_semantics, access_deleted and preserve_expiry, and no expiry, so a
+    document's TTL has to be set by a full-document write rather than here.
 
     At least one spec must be provided. As a rule of thumb, keep the combined number of
     specs across all categories to 16 or fewer — Couchbase limits subdocument operations
@@ -425,13 +528,25 @@ def mutate_subdocument(
         logger.warning(f"Error performing sub-document mutation in {keyspace}: {error}")
         return {"error": error}
 
+    try:
+        options = _mutate_in_write_options(durability)
+    except ValueError as e:
+        logger.warning(f"Error performing sub-document mutation in {keyspace}: {e}")
+        return {"error": str(e)}
+
     cluster = get_cluster_connection(ctx)
     bucket = connect_to_bucket(cluster, bucket_name)
 
     try:
         logger.debug(f"Performing sub-document mutation in {keyspace}")
         collection = bucket.scope(scope_name).collection(collection_name)
-        result = collection.mutate_in(document_id, specs)
+        # Call without an options object when none was requested, so the
+        # default path is byte-for-byte the one used before this parameter
+        # existed.
+        if options is None:
+            result = collection.mutate_in(document_id, specs)
+        else:
+            result = collection.mutate_in(document_id, specs, options)
     except Exception as e:
         error_context = getattr(e, "error_context", None)
         failed_index = getattr(error_context, "first_error_index", None)
@@ -444,36 +559,5 @@ def mutate_subdocument(
         )
         return {"error": f"{e}{detail}"}
 
-    response: dict[str, Any] = {}
-    for index, (op, path) in enumerate(spec_meta):
-        bucket_for_op = response.setdefault(op, {})
-        if op == "counter":
-            # The installed SDK constructs MutateInResult without a transcoder
-            # (unlike LookupInResult), which makes content_as always raise for
-            # mutate_in results — fall back to decoding the raw field value.
-            new_value = None
-            for read_new_value in (
-                lambda index=index: result.content_as[int](index),
-                lambda index=index: int(
-                    json.loads(result._orig.raw_result["fields"][index]["value"])
-                ),
-            ):
-                try:
-                    new_value = read_new_value()
-                    break
-                except Exception:  # noqa: S112 (expected fallback attempt, not a swallowed bug)
-                    continue
-
-            if new_value is None:
-                logger.warning(
-                    f"Counter mutation at '{path}' in {keyspace} committed but "
-                    "its new value could not be read from the SDK result."
-                )
-                bucket_for_op[path] = {"success": True}
-                continue
-            bucket_for_op[path] = {"success": True, "value": new_value}
-            continue
-        bucket_for_op[path] = {"success": True}
-
     logger.info(f"Successfully performed sub-document mutation in {keyspace}")
-    return response
+    return _mutate_in_response(result, spec_meta, keyspace)

--- a/tests/integration/test_subdoc_write_options.py
+++ b/tests/integration/test_subdoc_write_options.py
@@ -1,0 +1,196 @@
+"""
+Integration tests for durability on mutate_subdocument.
+
+What only a live server can show: a MAJORITY sub-document mutation is either
+satisfied by the cluster or refused as impossible, and never reports plain
+success without the guarantee having been requested. A mocked SDK cannot
+distinguish those three cases.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from conftest import (
+    create_mcp_session,
+    extract_payload,
+    get_test_collection,
+    get_test_scope,
+    require_test_bucket,
+)
+
+DURABILITY_LEVELS = [
+    "NONE",
+    "MAJORITY",
+    "MAJORITY_AND_PERSIST_TO_ACTIVE",
+    "PERSIST_TO_MAJORITY",
+]
+
+
+def _keyspace() -> dict[str, str]:
+    return {
+        "bucket_name": require_test_bucket(),
+        "scope_name": get_test_scope(),
+        "collection_name": get_test_collection(),
+    }
+
+
+async def _seed(session, doc_id: str, content: dict) -> None:
+    await session.call_tool(
+        "upsert_document_by_id",
+        arguments={**_keyspace(), "document_id": doc_id, "document_content": content},
+    )
+
+
+async def _delete(session, doc_id: str) -> None:
+    await session.call_tool(
+        "delete_document_by_id",
+        arguments={**_keyspace(), "document_id": doc_id},
+    )
+
+
+async def _read(session, doc_id: str) -> dict:
+    response = await session.call_tool(
+        "get_document_by_id",
+        arguments={**_keyspace(), "document_id": doc_id},
+    )
+    return extract_payload(response)
+
+
+@pytest.mark.asyncio
+async def test_durability_is_evaluated_by_the_cluster() -> None:
+    """A MAJORITY mutation is either satisfied or refused, never quietly ignored.
+
+    Both outcomes are correct depending on the cluster's replica count, so the
+    assertion is that whichever happened is internally consistent: on success
+    the mutation is readable, on refusal the error is a durability error. The
+    case this catches is the third one, where an option that never reached the
+    server reports success on a cluster that cannot provide the guarantee.
+    """
+    doc_id = f"test_subdur_{uuid.uuid4().hex[:8]}"
+
+    async with create_mcp_session() as session:
+        try:
+            await _seed(session, doc_id, {"n": 1})
+            response = await session.call_tool(
+                "mutate_subdocument",
+                arguments={
+                    **_keyspace(),
+                    "document_id": doc_id,
+                    "upsert_specs": [{"path": "durable", "value": True}],
+                    "durability": "MAJORITY",
+                },
+            )
+            payload = extract_payload(response)
+
+            if "error" in payload:
+                assert "durab" in payload["error"].lower(), payload["error"]
+            else:
+                assert payload["upsert"]["durable"]["success"] is True
+                assert (await _read(session, doc_id))["durable"] is True
+        finally:
+            await _delete(session, doc_id)
+
+
+@pytest.mark.asyncio
+async def test_none_durability_is_accepted_everywhere() -> None:
+    """NONE is satisfiable on any topology, so it must always succeed."""
+    doc_id = f"test_subdur_{uuid.uuid4().hex[:8]}"
+
+    async with create_mcp_session() as session:
+        try:
+            await _seed(session, doc_id, {"n": 1})
+            response = await session.call_tool(
+                "mutate_subdocument",
+                arguments={
+                    **_keyspace(),
+                    "document_id": doc_id,
+                    "upsert_specs": [{"path": "level", "value": "NONE"}],
+                    "durability": "NONE",
+                },
+            )
+            payload = extract_payload(response)
+            assert "error" not in payload, payload
+            assert (await _read(session, doc_id))["level"] == "NONE"
+        finally:
+            await _delete(session, doc_id)
+
+
+@pytest.mark.asyncio
+async def test_invalid_durability_is_rejected_and_nothing_is_mutated() -> None:
+    doc_id = f"test_subdur_{uuid.uuid4().hex[:8]}"
+
+    async with create_mcp_session() as session:
+        try:
+            await _seed(session, doc_id, {"untouched": True})
+            response = await session.call_tool(
+                "mutate_subdocument",
+                arguments={
+                    **_keyspace(),
+                    "document_id": doc_id,
+                    "upsert_specs": [{"path": "should_not_exist", "value": 1}],
+                    "durability": "NOT_A_LEVEL",
+                },
+            )
+            payload = extract_payload(response)
+            assert "error" in payload
+            assert "NOT_A_LEVEL" in payload["error"]
+
+            document = await _read(session, doc_id)
+            assert document == {"untouched": True}
+        finally:
+            await _delete(session, doc_id)
+
+
+@pytest.mark.asyncio
+async def test_every_documented_level_is_accepted_by_the_tool() -> None:
+    """Each level must be understood at the tool boundary.
+
+    A level the cluster cannot satisfy is allowed to fail, but it must fail
+    with a durability error from the server rather than a validation error
+    from the tool, which is what a typo in the mapping would produce.
+    """
+    async with create_mcp_session() as session:
+        for level in DURABILITY_LEVELS:
+            doc_id = f"test_subdur_{uuid.uuid4().hex[:8]}"
+            try:
+                await _seed(session, doc_id, {"n": 1})
+                response = await session.call_tool(
+                    "mutate_subdocument",
+                    arguments={
+                        **_keyspace(),
+                        "document_id": doc_id,
+                        "upsert_specs": [{"path": "lvl", "value": level}],
+                        "durability": level,
+                    },
+                )
+                payload = extract_payload(response)
+                if "error" in payload:
+                    assert "must be one of" not in payload["error"], level
+            finally:
+                await _delete(session, doc_id)
+
+
+@pytest.mark.asyncio
+async def test_omitting_the_options_leaves_behaviour_unchanged() -> None:
+    """The pre-existing call path must be untouched when nothing is requested."""
+    doc_id = f"test_subdur_{uuid.uuid4().hex[:8]}"
+
+    async with create_mcp_session() as session:
+        try:
+            await _seed(session, doc_id, {"n": 1})
+            response = await session.call_tool(
+                "mutate_subdocument",
+                arguments={
+                    **_keyspace(),
+                    "document_id": doc_id,
+                    "upsert_specs": [{"path": "plain", "value": True}],
+                },
+            )
+            payload = extract_payload(response)
+            assert "error" not in payload, payload
+            assert payload["upsert"]["plain"]["success"] is True
+            assert (await _read(session, doc_id))["plain"] is True
+        finally:
+            await _delete(session, doc_id)

--- a/tests/unit/test_subdoc_write_options.py
+++ b/tests/unit/test_subdoc_write_options.py
@@ -1,0 +1,110 @@
+"""Unit tests for durability on mutate_subdocument."""
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from couchbase.durability import ServerDurability
+
+from cb_mcp.tools.kv import DURABILITY_LEVELS, mutate_subdocument
+
+
+def _make_ctx_with_collection() -> tuple[SimpleNamespace, MagicMock, MagicMock]:
+    """Build a Context plus its underlying cluster + collection mock."""
+    cluster = MagicMock()
+    bucket = MagicMock()
+    collection = MagicMock()
+    bucket.scope.return_value.collection.return_value = collection
+    cluster.bucket.return_value = bucket
+
+    ctx = SimpleNamespace(
+        request_context=SimpleNamespace(
+            lifespan_context=SimpleNamespace(
+                cluster_provider=SimpleNamespace(get_cluster=lambda c: cluster),
+            )
+        )
+    )
+    return ctx, cluster, collection
+
+
+SPEC = [{"path": "a", "value": 1}]
+
+
+class TestDurability:
+    def test_omitting_it_preserves_the_previous_call_shape(self) -> None:
+        """The default must remain exactly what it was: no options object."""
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            mutate_subdocument(ctx, "b", "s", "c", "doc1", upsert_specs=SPEC)
+
+        assert len(collection.mutate_in.call_args.args) == 2
+
+    def test_every_documented_level_reaches_the_sdk(self) -> None:
+        for name, expected in DURABILITY_LEVELS.items():
+            ctx, cluster, collection = _make_ctx_with_collection()
+
+            with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+                result = mutate_subdocument(
+                    ctx, "b", "s", "c", "doc1", upsert_specs=SPEC, durability=name
+                )
+
+            assert "error" not in result, name
+            options = dict(collection.mutate_in.call_args.args[2])
+            durability = options["durability"]
+            assert isinstance(durability, ServerDurability), name
+            assert durability.level is expected, name
+
+    def test_durability_level_key_is_never_sent(self) -> None:
+        """The SDK reads ``durability``; ``durability_level`` is silently dropped.
+
+        The Options classes are unvalidated dict subclasses, so sending the
+        wrong key is accepted, discarded, and the mutation then reports success
+        without ever having requested the guarantee. This asserts the mistake
+        is not present.
+        """
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            mutate_subdocument(
+                ctx, "b", "s", "c", "doc1", upsert_specs=SPEC, durability="MAJORITY"
+            )
+
+        options = dict(collection.mutate_in.call_args.args[2])
+        assert "durability_level" not in options
+        assert "durability" in options
+
+    def test_documented_levels_match_the_docstring(self) -> None:
+        """Guard against the mapping and the docstring drifting apart."""
+        for name in DURABILITY_LEVELS:
+            assert f'"{name}"' in mutate_subdocument.__doc__, name
+
+    def test_invalid_level_is_rejected_and_nothing_is_mutated(self) -> None:
+        ctx, cluster, collection = _make_ctx_with_collection()
+
+        with patch("cb_mcp.tools.kv.get_cluster_connection", return_value=cluster):
+            result = mutate_subdocument(
+                ctx, "b", "s", "c", "doc1", upsert_specs=SPEC, durability="NOT_A_LEVEL"
+            )
+
+        assert "error" in result
+        assert "NOT_A_LEVEL" in result["error"]
+        for level in DURABILITY_LEVELS:
+            assert level in result["error"]
+        collection.mutate_in.assert_not_called()
+
+
+class TestNoExpiryOption:
+    def test_mutate_in_options_has_no_expiry_key(self) -> None:
+        """MutateInOptions has no expiry; the docstring must not imply one.
+
+        MutateInOptionsBase accepts timeout, cas, durability, store_semantics,
+        access_deleted and preserve_expiry. A TTL cannot be set through
+        mutate_in, so this tool must not grow an expiry parameter that the SDK
+        would silently drop.
+        """
+        signature = inspect.signature(mutate_subdocument)
+        assert "expiry_seconds" not in signature.parameters
+        assert "expiry" not in signature.parameters


### PR DESCRIPTION
## Related Issue

Resolves: https://github.com/couchbase/mcp-server-couchbase/issues/270

## What does this change do?

Adds an optional `durability` parameter to `mutate_subdocument`, accepting the
same four level names as the other KV write tools: `NONE`,
`MAJORITY`, `MAJORITY_AND_PERSIST_TO_ACTIVE` and `PERSIST_TO_MAJORITY`.

Nothing else changes. No new tool, no change to any return shape, and no
existing test required modification. With the parameter omitted the SDK is
called with exactly the same two positional arguments as before, and a test
asserts that.

## Why is this change needed?

`mutate_subdocument` is the only KV write tool that could not ask for a
durability guarantee. Every sub-document mutation was acknowledged from the
active node's memory, with no way to request replication or persistence, even
though `MutateInOptions` supports it.

That gap matters more here than it looks. Sub-document mutation is the tool an
agent reaches for when it is changing one field of a record that already exists
and that a person is acting on: a status, a flag, an assignment. Those are
precisely the writes worth making durable, and they were the ones that could
not be.

## A correction to the interface proposed in the issue

Issue #270 proposes `mutate_subdocument: store_semantics, durability,
expiry_seconds, cas`. The `expiry_seconds` part of that proposal is not
implementable and should be disregarded.

`MutateInOptions` has no expiry. From the 4.6.2 source:

```python
class MutateInOptionsBase(DurabilityOptionBlockBase):
    def __init__(self,
                 timeout=None, cas=0, durability=None,
                 store_semantics=None, access_deleted=None,
                 preserve_expiry=None):
```

`timeout`, `cas`, `durability`, `store_semantics`, `access_deleted` and
`preserve_expiry`, and no expiry. `UpsertOptions` has one; `MutateInOptions`
does not. A TTL has to be set by a full-document write. The docstring says so
explicitly, and a unit test asserts the tool has no `expiry_seconds` parameter,
so the mistake cannot be reintroduced by someone reading the issue rather than
the SDK.

`preserve_expiry` is real and is deliberately not included here. It cannot be
demonstrated end to end in this PR, because on this branch alone there is no way
to give a document a TTL through the tool surface in the first place. It belongs
with whichever change adds expiry to the full-document writes.

## Evidence of Testing

Tested at commit `1402126652e7e52986fa39a946160791302c3d31`.

**Static checks:**

```
uv run ruff check src/            ->  All checks passed
```

**Unit tests:**

```
uv run pytest tests/unit -q       ->  513 passed
```

New unit tests in `tests/unit/test_subdoc_write_options.py`. One asserts that
every level named in the docstring is accepted by the mapping, so the
documentation and the code cannot drift apart. Another asserts the options
object never carries a `durability_level` key, for the reason in the next
section.

**Integration tests, self-managed Couchbase Server Enterprise 8.0.1, two-node
Docker cluster with one replica:**

```
uv run pytest tests/integration/test_subdoc_write_options.py \
              tests/integration/test_kv_tools.py \
              tests/integration/test_read_only.py -v    ->  40 passed
```

**Integration tests, Couchbase Capella 8.0.2 (AWS us-east-1), travel-sample:**

```
uv run pytest tests/integration/test_subdoc_write_options.py \
              tests/integration/test_read_only.py -v    ->  10 passed
```

**Full suite, against a baseline on unmodified `main`:**

```
main @ 660ade3, untouched   ->  3 failed, 123 passed, 12 skipped   (138 collected)
this branch @ 1402126       ->  3 failed, 128 passed, 12 skipped   (143 collected)
```

The same three failures, the same twelve skips, and the pass count up by exactly
the five tests this branch adds. Both runs are on the same cluster, minutes
apart.

The three failures are `test_fts_tools.py::test_run_fts_query_*`, where the
seeded Search index never becomes queryable inside the fixture's 300-second
timeout on a local cluster, reporting `query succeeded but returned no rows for
the seeded marker`. The twelve skips are `test_index_tools.py` and
`test_performance_tools.py` declining to assert against a cluster with no GSI
indexes and no query history. Both are present on `main` before this change.
Nothing here touches Search, GSI or the performance tools.

A note for anyone reproducing this: a local cluster whose GSI indexer storage
mode was never set also fails the three `test_index_tools.py` create and drop
tests with `Please Set Indexer Storage Mode Before Create Index`. That is the
cluster, not this change; `POST /settings/indexes` with `storageMode=plasma`
clears it.

The integration tests cover what a live server shows and mocks cannot. A
`MAJORITY` mutation is either satisfied by the cluster or refused as impossible.
Both are correct answers, so the test asserts that whichever occurred is
internally consistent: on success the mutation is read back and verified, on
refusal the error must be a durability error. What this catches is the third
case, where an option that never reached the server reports plain success on a
cluster that cannot provide the guarantee.

**Environments tested** (both required):

- [x] Couchbase Capella (version: 8.0.2, AWS us-east-1)
- [x] Self-managed Couchbase Server (version: Enterprise 8.0.1, two-node Docker)

**Manual verification:**

Exercised through a scripted MCP client over stdio, built on the official `mcp`
Python SDK, against the two-node self-managed cluster. MCP Inspector needs Node,
which the test machine does not have. These are real calls with their real
responses.

```
CALL  mutate_subdocument  (durability=MAJORITY)
      response : {"upsert":{"durable":{"success":true}}}

CALL  get_document_by_id  (reads the durable mutation back)
      response : {"tool":"manual check","pr":5,"durable":true}

CALL  mutate_subdocument  (durability="NOT_A_LEVEL")
      response : {"error":"durability must be one of
                  ['MAJORITY','MAJORITY_AND_PERSIST_TO_ACTIVE','NONE',
                  'PERSIST_TO_MAJORITY']; got 'NOT_A_LEVEL'"}

CALL  get_document_by_id  (document is unchanged by the rejection)
      response : {"tool":"manual check","pr":5,"durable":true}
```

The last two calls are the pair worth reading. The rejection names the valid
levels and happens before any mutation is attempted, and the document is then
read back to show that the rejected call changed nothing.

**Read-only mode:** no new tools and no reclassification, so existing behaviour
stands. `tests/integration/test_read_only.py` passed in both environments as
part of the runs above, covering `mutate_subdocument` staying filtered out of a
read-only session.

## Compatibility Considerations

- **Managed MCP:** no change. Nothing touches `cb_mcp.core`, and the cluster is
  still resolved through `ClusterProvider` via the request context.
- **Tool interfaces:** one optional parameter, defaulted. With it omitted the
  SDK is called with the same two positional arguments as before, covered by a
  test.
- **Return shapes:** unchanged.
- **Annotations:** `TOOL_ANNOTATIONS` reviewed and left as it was. The tool's
  effect on cluster state is unchanged; only the acknowledgement requirement
  differs.
- **Capella vs self-managed:** identical behaviour, confirmed by running the
  same tests against both. Durability above `NONE` needs enough replicas on
  either deployment, and the tool surfaces the server's refusal instead of
  quietly downgrading.
- **Dependencies:** none added.
- **The `durability` option key:** durability travels under the SDK's
  `durability` key wrapped in `ServerDurability`. The `*Options` classes are
  unvalidated `dict` subclasses, so passing `durability_level` is accepted and
  then dropped silently: the mutation succeeds, the caller is told it succeeded,
  and the guarantee was never requested. A unit test asserts that key is absent.
- **`_mutate_in_response`:** extracted from `mutate_subdocument` with its
  behaviour unchanged. Adding the parameter pushed that function past this
  project's configured branch and statement limits, and lifting the block out is
  what brings it back under them.

## Note on the other PRs against this issue

This PR stands alone against `660ade3` and can be merged, deferred or dropped
without reference to #271, #272, #273 or #274. Its tests reference none of their
parameters.

Two pieces of code are intentionally identical to code in those PRs, so that
whichever merges second resolves by deleting a duplicate rather than
reconciling two different implementations:

- the `DURABILITY_LEVELS` mapping, also added by #271
- the `_mutate_in_response` extraction, also added by #272 and #273

All of them also touch the KV table in `README.md` and `DOCKER.md`. That is a
textual overlap and not a dependency. Sequence them however suits you, and I am
happy to collapse the duplicates into whichever lands first.

## Checklist

- [x] Linked to an issue
- [x] Uses the Couchbase SDK (no REST)
- [x] Works on both Capella and self-managed Couchbase Server
- [x] No changes to `cb_mcp.core` contracts / managed MCP interfaces
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Read-only mode and tool annotations handled. No new tools, and the
      existing classification and annotations are unchanged.
- [x] Evidence of testing included above
- [x] Docs updated (README, DOCKER.md)
- [x] Lint and pre-commit pass. Note that `ruff format --check src/` already
      fails on `main` for a pre-existing lambda in `kv.py`. This PR neither adds
      to that nor fixes it, so the diff stays limited to the change itself.
